### PR TITLE
Add HAPS hadrons FF1.0 cards and COMPASS data used in arXiv: 2605.31325 and arXiv:2606.16754.

### DIFF
--- a/config/HAPS-KaFF1.0-NLO.yaml
+++ b/config/HAPS-KaFF1.0-NLO.yaml
@@ -1,0 +1,121 @@
+#################################
+# Predictions
+#################################
+Predictions:
+  # Perturbative order, 0: LO, 1: NLO
+  perturbative order: 1
+
+  # Initial scale in GeV to be used for the DGLAP evolution of the FFs.
+  mu0: 5
+
+  # Quark thresholds
+  thresholds: [0, 0, 0, 1.51, 4.92]
+
+  # Strong coupling
+  alphas:
+    aref: 0.118
+    Qref: 91.1876
+
+  # Fine-structure constant
+  alphaem:
+    aref: 0.00776578395589
+    Qref: 91.1876
+
+  # APFEL++ grid
+  xgrid:
+    - [100, 1e-2, 3]
+    - [60,  2e-1, 3]
+    - [40,  8e-1, 3]
+
+  # PDF set
+  pdfset:
+    name: NNPDF40_nlo_pch_as_01180
+    member: -1 #N>=0 for a specific member (0 for central) ; N<0 for all members to be used randomly(flat dist)
+    
+#################################
+# Optimiser
+#################################
+# Parameters of the optimiser managed by ceres-solver
+Optimizer:
+  max_num_iterations: 3000
+  chi2_tolerance: 3
+#################################
+# NNAD
+#################################
+NNAD:
+  # Initialisation seed
+  seed: 4
+  # Architecture
+  architecture: [1, 20, 7]
+  # The output function can be either the activation function of the
+  # NN (0), or linear (1), or quadratic (2). If this entry is absent a
+  # linear function is assumed.
+  output function: 2
+  # The flavour map gives the the specific combinations of
+  # distributions in the physical-basis (d, u, s, ..) to be fitted to
+  # the data. The number of combinations has to match the number of
+  # nodes of the output layer of the NN given in the
+  # architecture. When defining the flavour map, one should keep in
+  # mind that the code computes predictions using the QCD-evolution
+  # basis (Sigma, V, T3, ...). Therefore, in general,
+  # QCD-evolution-like combinations should be preferred. Moreover, the
+  # distributions are assumed to be for the positive charge of the a
+  # given hadronic species. The negative distributions are derived
+  # using charge conjugation (q->qbar).
+
+  #             tb bb cb sb ub db g  d  u  s  c  b  t  # Combinations to be fitted (i.e. output of the NN):
+  flavour map: [0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, # - sb
+    0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, # - g
+    0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, # - s = ubar
+    0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, # - u
+    0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, # - d+
+    0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, # - c+
+    0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0] # - b+
+  #tb bb cb sb ub db g  d  u  s  c  b  t
+  combine: true
+#################################
+# Data
+#################################
+Data:
+  # Seed used for the replica generation and the splitting between
+  # training and validation (do not use a too large number here in
+  # order to avoid correlation in the replica generation).
+  seed: 0
+  # Hadronic species being fitted. This is used to make sure that all
+  # data sets included in the fit actually refer to the correct
+  # species.
+  hadron: KA
+  # Datasets to be included in the fit along with specific cuts and
+  # traning fraction. Each single dataset can implement an arbitrary
+  # number of cuts determined by the name of the appropriate function
+  # (e.g. zcut) and the allowed range.
+  sets:
+    - {name: "COMPASS $K^+$ 2026",          file: "COMPASS_KA_PLUS_2026.yaml",            cuts: [{name: Qcut, min: 1.7, max: 50}],      training fraction: 0.5}
+    - {name: "COMPASS $K^-$ 2026",          file: "COMPASS_KA_MINUS_2026.yaml",           cuts: [{name: Qcut, min: 1.7, max: 50}],      training fraction: 0.5}
+    - {name: "COMPASS $K^+$ 2025",          file: "COMPASS_KA_PLUS_2025.yaml",            cuts: [{name: Qcut, min: 1.7, max: 50}],      training fraction: 0.5}
+    - {name: "COMPASS $K^-$ 2025",          file: "COMPASS_KA_MINUS_2025.yaml",           cuts: [{name: Qcut, min: 1.7, max: 50}],      training fraction: 0.5}
+    - {name: "HERMES $K^-$ deuteron", file: "HERMES_KA_MINUS_DEUTERON.yaml", cuts: [{name: Qcut, min: 1.7, max: 50}, {name: zcut, min: 0.2, max: 0.8}], training fraction: 0.5}
+    - {name: "HERMES $K^-$ proton", file: "HERMES_KA_MINUS_PROTON.yaml", cuts: [{name: Qcut, min: 1.7, max: 50}, {name: zcut, min: 0.2, max: 0.8}], training fraction: 0.5}
+    - {name: "HERMES $K^+$ deuteron", file: "HERMES_KA_PLUS_DEUTERON.yaml", cuts: [{name: Qcut, min: 1.7, max: 50}, {name: zcut, min: 0.2, max: 0.8}], training fraction: 0.5}
+    - {name: "HERMES $K^+$ proton", file: "HERMES_KA_PLUS_PROTON.yaml", cuts: [{name: Qcut, min: 1.7, max: 50}, {name: zcut, min: 0.2, max: 0.8}], training fraction: 0.5}
+#    - {name: "COMPASS $K^-$", file: "COMPASS_KA_MINUS_DECORR.yaml", cuts: [{name: Qcut, min: 1.7, max: 50}], training fraction: 0.5}
+#    - {name: "COMPASS $K^+$", file: "COMPASS_KA_PLUS_DECORR.yaml", cuts: [{name: Qcut, min: 1.7, max: 50}], training fraction: 0.5}
+    - {name: "BELLE $K^\\pm$", file: "BELLE_KA_PLUS_MINUS.yaml", cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "BABAR conventional $K^\\pm$", file: "BABAR_KA_PLUS_MINUS_CONVENTIONAL.yaml", cuts: [{name: zcut, min: 0.2, max: 0.9}], training fraction: 0.5}
+    - {name: "TASSO 12 GeV $K^\\pm$", file: "TASSO_12_KA_PLUS_MINUS.yaml", cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TASSO 14 GeV $K^\\pm$", file: "TASSO_14_KA_PLUS_MINUS.yaml", cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TASSO 22 GeV $K^\\pm$", file: "TASSO_22_KA_PLUS_MINUS.yaml", cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TPC $K^\\pm$", file: "TPC_KA_PLUS_MINUS.yaml", cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TASSO 30 GeV $K^\\pm$", file: "TASSO_30_KA_PLUS_MINUS.yaml", cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TASSO 34 GeV $K^\\pm$", file: "TASSO_34_KA_PLUS_MINUS.yaml", cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TASSO 44 GeV $K^\\pm$", file: "TASSO_44_KA_PLUS_MINUS.yaml", cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TOPAZ $K^\\pm$", file: "TOPAZ_KA_PLUS_MINUS.yaml", cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "ALEPH $K^\\pm$", file: "ALEPH_KA_PLUS_MINUS.yaml", cuts: [{name: zcut, min: 0.02, max: 0.9}], training fraction: 0.5}
+    - {name: "DELPHI total $K^\\pm$", file: "DELPHI_KA_PLUS_MINUS.yaml", cuts: [{name: zcut, min: 0.02, max: 0.9}], training fraction: 0.5}
+    - {name: "DELPHI $uds$ $K^\\pm$", file: "DELPHI_KA_PLUS_MINUS_UDS.yaml", cuts: [{name: zcut, min: 0.02, max: 0.9}], training fraction: 0.5}
+    - {name: "DELPHI bottom $K^\\pm$", file: "DELPHI_KA_PLUS_MINUS_B.yaml", cuts: [{name: zcut, min: 0.02, max: 0.9}], training fraction: 0.5}
+    - {name: "OPAL $K^\\pm$", file: "OPAL_KA_PLUS_MINUS.yaml", cuts: [{name: zcut, min: 0.02, max: 0.9}], training fraction: 0.5}
+    - {name: "SLD total $K^\\pm$", file: "SLD_KA_PLUS_MINUS.yaml", cuts: [{name: zcut, min: 0.02, max: 0.9}], training fraction: 0.5}
+    - {name: "SLD $uds$ $K^\\pm$", file: "SLD_KA_PLUS_MINUS_UDS.yaml", cuts: [{name: zcut, min: 0.02, max: 0.9}], training fraction: 0.5}
+    #- {name: "SLD charm $K^\\pm$",     file: "SLD_KA_PLUS_MINUS_C.yaml",        cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+    - {name: "SLD bottom $K^\\pm$", file: "SLD_KA_PLUS_MINUS_B.yaml", cuts: [{name: zcut, min: 0.02, max: 0.9}], training fraction: 0.5}

--- a/config/HAPS-KaFF1.0-NNLO.yaml
+++ b/config/HAPS-KaFF1.0-NNLO.yaml
@@ -1,0 +1,121 @@
+#################################
+# Predictions
+#################################
+Predictions:
+  # Perturbative order, 0: LO, 1: NLO
+  perturbative order: 2
+
+  # Initial scale in GeV to be used for the DGLAP evolution of the FFs.
+  mu0: 5
+
+  # Quark thresholds
+  thresholds: [0, 0, 0, 1.51, 4.92]
+
+  # Strong coupling
+  alphas:
+    aref: 0.118
+    Qref: 91.1876
+
+  # Fine-structure constant
+  alphaem:
+    aref: 0.00776578395589
+    Qref: 91.1876
+
+  # APFEL++ grid
+  xgrid:
+    - [100, 1e-2, 3]
+    - [60,  2e-1, 3]
+    - [40,  8e-1, 3]
+
+  # PDF set
+  pdfset:
+    name: NNPDF40_nnlo_pch_as_01180
+    member: -1 #N>=0 for a specific member (0 for central) ; N<0 for all members to be used randomly(flat dist)
+    
+#################################
+# Optimiser
+#################################
+# Parameters of the optimiser managed by ceres-solver
+Optimizer:
+  max_num_iterations: 3000
+  chi2_tolerance: 3
+#################################
+# NNAD
+#################################
+NNAD:
+  # Initialisation seed
+  seed: 4
+  # Architecture
+  architecture: [1, 20, 7]
+  # The output function can be either the activation function of the
+  # NN (0), or linear (1), or quadratic (2). If this entry is absent a
+  # linear function is assumed.
+  output function: 2
+  # The flavour map gives the the specific combinations of
+  # distributions in the physical-basis (d, u, s, ..) to be fitted to
+  # the data. The number of combinations has to match the number of
+  # nodes of the output layer of the NN given in the
+  # architecture. When defining the flavour map, one should keep in
+  # mind that the code computes predictions using the QCD-evolution
+  # basis (Sigma, V, T3, ...). Therefore, in general,
+  # QCD-evolution-like combinations should be preferred. Moreover, the
+  # distributions are assumed to be for the positive charge of the a
+  # given hadronic species. The negative distributions are derived
+  # using charge conjugation (q->qbar).
+
+  #             tb bb cb sb ub db g  d  u  s  c  b  t  # Combinations to be fitted (i.e. output of the NN):
+  flavour map: [0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, # - sb
+    0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, # - g
+    0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, # - s = ubar
+    0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, # - u
+    0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, # - d+
+    0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, # - c+
+    0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0] # - b+
+  #tb bb cb sb ub db g  d  u  s  c  b  t
+  combine: true
+#################################
+# Data
+#################################
+Data:
+  # Seed used for the replica generation and the splitting between
+  # training and validation (do not use a too large number here in
+  # order to avoid correlation in the replica generation).
+  seed: 0
+  # Hadronic species being fitted. This is used to make sure that all
+  # data sets included in the fit actually refer to the correct
+  # species.
+  hadron: KA
+  # Datasets to be included in the fit along with specific cuts and
+  # traning fraction. Each single dataset can implement an arbitrary
+  # number of cuts determined by the name of the appropriate function
+  # (e.g. zcut) and the allowed range.
+  sets:
+    - {name: "COMPASS $K^+$ 2026",          file: "COMPASS_KA_PLUS_2026.yaml",            cuts: [{name: Qcut, min: 1.7, max: 50}],      training fraction: 0.5}
+    - {name: "COMPASS $K^-$ 2026",          file: "COMPASS_KA_MINUS_2026.yaml",           cuts: [{name: Qcut, min: 1.7, max: 50}],      training fraction: 0.5}
+    - {name: "COMPASS $K^+$ 2025",          file: "COMPASS_KA_PLUS_2025.yaml",            cuts: [{name: Qcut, min: 1.7, max: 50}],      training fraction: 0.5}
+    - {name: "COMPASS $K^-$ 2025",          file: "COMPASS_KA_MINUS_2025.yaml",           cuts: [{name: Qcut, min: 1.7, max: 50}],      training fraction: 0.5}
+    - {name: "HERMES $K^-$ deuteron", file: "HERMES_KA_MINUS_DEUTERON.yaml", cuts: [{name: Qcut, min: 1.7, max: 50}, {name: zcut, min: 0.2, max: 0.8}], training fraction: 0.5}
+    - {name: "HERMES $K^-$ proton", file: "HERMES_KA_MINUS_PROTON.yaml", cuts: [{name: Qcut, min: 1.7, max: 50}, {name: zcut, min: 0.2, max: 0.8}], training fraction: 0.5}
+    - {name: "HERMES $K^+$ deuteron", file: "HERMES_KA_PLUS_DEUTERON.yaml", cuts: [{name: Qcut, min: 1.7, max: 50}, {name: zcut, min: 0.2, max: 0.8}], training fraction: 0.5}
+    - {name: "HERMES $K^+$ proton", file: "HERMES_KA_PLUS_PROTON.yaml", cuts: [{name: Qcut, min: 1.7, max: 50}, {name: zcut, min: 0.2, max: 0.8}], training fraction: 0.5}
+#    - {name: "COMPASS $K^-$", file: "COMPASS_KA_MINUS_DECORR.yaml", cuts: [{name: Qcut, min: 1.7, max: 50}], training fraction: 0.5}
+#    - {name: "COMPASS $K^+$", file: "COMPASS_KA_PLUS_DECORR.yaml", cuts: [{name: Qcut, min: 1.7, max: 50}], training fraction: 0.5}
+    - {name: "BELLE $K^\\pm$", file: "BELLE_KA_PLUS_MINUS.yaml", cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "BABAR conventional $K^\\pm$", file: "BABAR_KA_PLUS_MINUS_CONVENTIONAL.yaml", cuts: [{name: zcut, min: 0.2, max: 0.9}], training fraction: 0.5}
+    - {name: "TASSO 12 GeV $K^\\pm$", file: "TASSO_12_KA_PLUS_MINUS.yaml", cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TASSO 14 GeV $K^\\pm$", file: "TASSO_14_KA_PLUS_MINUS.yaml", cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TASSO 22 GeV $K^\\pm$", file: "TASSO_22_KA_PLUS_MINUS.yaml", cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TPC $K^\\pm$", file: "TPC_KA_PLUS_MINUS.yaml", cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TASSO 30 GeV $K^\\pm$", file: "TASSO_30_KA_PLUS_MINUS.yaml", cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TASSO 34 GeV $K^\\pm$", file: "TASSO_34_KA_PLUS_MINUS.yaml", cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TASSO 44 GeV $K^\\pm$", file: "TASSO_44_KA_PLUS_MINUS.yaml", cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TOPAZ $K^\\pm$", file: "TOPAZ_KA_PLUS_MINUS.yaml", cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "ALEPH $K^\\pm$", file: "ALEPH_KA_PLUS_MINUS.yaml", cuts: [{name: zcut, min: 0.02, max: 0.9}], training fraction: 0.5}
+    - {name: "DELPHI total $K^\\pm$", file: "DELPHI_KA_PLUS_MINUS.yaml", cuts: [{name: zcut, min: 0.02, max: 0.9}], training fraction: 0.5}
+    - {name: "DELPHI $uds$ $K^\\pm$", file: "DELPHI_KA_PLUS_MINUS_UDS.yaml", cuts: [{name: zcut, min: 0.02, max: 0.9}], training fraction: 0.5}
+    - {name: "DELPHI bottom $K^\\pm$", file: "DELPHI_KA_PLUS_MINUS_B.yaml", cuts: [{name: zcut, min: 0.02, max: 0.9}], training fraction: 0.5}
+    - {name: "OPAL $K^\\pm$", file: "OPAL_KA_PLUS_MINUS.yaml", cuts: [{name: zcut, min: 0.02, max: 0.9}], training fraction: 0.5}
+    - {name: "SLD total $K^\\pm$", file: "SLD_KA_PLUS_MINUS.yaml", cuts: [{name: zcut, min: 0.02, max: 0.9}], training fraction: 0.5}
+    - {name: "SLD $uds$ $K^\\pm$", file: "SLD_KA_PLUS_MINUS_UDS.yaml", cuts: [{name: zcut, min: 0.02, max: 0.9}], training fraction: 0.5}
+    #- {name: "SLD charm $K^\\pm$",     file: "SLD_KA_PLUS_MINUS_C.yaml",        cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+    - {name: "SLD bottom $K^\\pm$", file: "SLD_KA_PLUS_MINUS_B.yaml", cuts: [{name: zcut, min: 0.02, max: 0.9}], training fraction: 0.5}

--- a/config/HAPS-PiFF1.0-NLO.yaml
+++ b/config/HAPS-PiFF1.0-NLO.yaml
@@ -1,0 +1,126 @@
+#################################
+# Predictions
+#################################
+Predictions:
+  # Perturbative order, 0: LO, 1: NLO
+  perturbative order: 1
+
+  # Initial scale in GeV to be used for the DGLAP evolution of the FFs.
+  mu0: 5
+
+  # Quark thresholds
+  thresholds: [0, 0, 0, 1.51, 4.92]
+
+  # Strong coupling
+  alphas:
+    aref: 0.118
+    Qref: 91.1876
+
+  # Fine-structure constant
+  alphaem:
+    aref: 0.00776578395589
+    Qref: 91.1876
+
+  # APFEL++ grid
+  xgrid:
+    - [100, 1e-2, 3]
+    - [60,  2e-1, 3]
+    - [40,  8e-1, 3]
+
+  # PDF set
+  pdfset:
+    name: NNPDF40_nlo_pch_as_01180
+    member: -1 #N>=0 for a specific member (0 for central) ; N<0 for all members to be used randomly(flat dist)
+
+#################################
+# Optimiser
+#################################
+# Parameters of the optimiser managed by ceres-solver
+Optimizer:
+  max_num_iterations: 3000
+  chi2_tolerance: 3
+
+#################################
+# NNAD
+#################################
+NNAD:
+  # Initialisation seed
+  seed: 0
+
+  # Architecture
+  architecture: [1, 20, 7]
+
+  # The output function can be either the activation function of the
+  # NN (0), or linear (1), or quadratic (2). If this entry is absent a
+  # linear function is assumed.
+  output function: 2
+
+  # The flavour map gives the the specific combinations of
+  # distributions in the physical-basis (d, u, s, ..) to be fitted to
+  # the data. The number of combinations has to match the number of
+  # nodes of the output layer of the NN given in the
+  # architecture. When defining the flavour map, one should keep in
+  # mind that the code computes predictions using the QCD-evolution
+  # basis (Sigma, V, T3, ...). Therefore, in general,
+  # QCD-evolution-like combinations should be preferred. Moreover, the
+  # distributions are assumed to be for the positive charge of the a
+  # given hadronic species. The negative distributions are derived
+  # using charge conjugation (q->qbar).
+
+  #             tb  bb  cb  sb  ub  db  g   d   u   s   c   b   t  # Combinations to be fitted (i.e. output of the NN):
+  flavour map: [0,  0,  0,  0,  0,  1,  0,  0,  0,  0,  0,  0,  0, # - db
+                0,  0,  0,  0,  0,  0,  1,  0,  0,  0,  0,  0,  0, # - g
+                0,  0,  0,  0,  1,  0,  0,  1,  0,  0,  0,  0,  0, # - d = ubar
+                0,  0,  0,  0,  0,  0,  0,  0,  1,  0,  0,  0,  0, # - u
+                0,  0,  0,  1,  0,  0,  0,  0,  0,  1,  0,  0,  0, # - s+
+                0,  0,  1,  0,  0,  0,  0,  0,  0,  0,  1,  0,  0, # - c+
+                0,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  1,  0] # - b+
+  combine: true
+#################################
+# Data
+#################################
+Data:
+  # Seed used for the replica generation and the splitting between
+  # training and validation (do not use a too large number here in
+  # order to avoid correlation in the replica generation).
+  seed: 2
+
+  # Hadronic species being fitted. This is used to make sure that all
+  # data sets included in the fit actually refer to the correct
+  # species.
+  hadron: PI
+
+  # Datasets to be included in the fit along with specific cuts and
+  # traning fraction. Each single dataset can implement an arbitrary
+  # number of cuts determined by the name of the appropriate function
+  # (e.g. zcut) and the allowed range.
+  sets: 
+    - {name: "COMPASS $pi^+$ 2026",          file: "COMPASS_PI_PLUS_2026.yaml",            cuts: [{name: Qcut, min: 1.5, max: 50}],      training fraction: 0.5}
+    - {name: "COMPASS $pi^-$ 2026",          file: "COMPASS_PI_MINUS_2026.yaml",           cuts: [{name: Qcut, min: 1.5, max: 50}],      training fraction: 0.5}
+    - {name: "COMPASS $pi^+$ 2025",          file: "COMPASS_PI_PLUS_2025.yaml",            cuts: [{name: Qcut, min: 1.5, max: 50}],      training fraction: 0.5}
+    - {name: "COMPASS $pi^-$ 2025",          file: "COMPASS_PI_MINUS_2025.yaml",           cuts: [{name: Qcut, min: 1.5, max: 50}],      training fraction: 0.5}
+    - {name: "HERMES $\\pi^-$ deuteron",  file: "HERMES_PI_MINUS_DEUTERON.yaml",   cuts: [{name: Qcut, min: 1.5, max: 50}, {name: zcut, min: 0.2, max: 0.8}], training fraction: 0.5}
+    - {name: "HERMES $\\pi^-$ proton",    file: "HERMES_PI_MINUS_PROTON.yaml",     cuts: [{name: Qcut, min: 1.5, max: 50}, {name: zcut, min: 0.2, max: 0.8}], training fraction: 0.5}
+    - {name: "HERMES $\\pi^+$ deuteron",  file: "HERMES_PI_PLUS_DEUTERON.yaml",    cuts: [{name: Qcut, min: 1.5, max: 50}, {name: zcut, min: 0.2, max: 0.8}], training fraction: 0.5}
+    - {name: "HERMES $\\pi^+$ proton",    file: "HERMES_PI_PLUS_PROTON.yaml",      cuts: [{name: Qcut, min: 1.5, max: 50}, {name: zcut, min: 0.2, max: 0.8}], training fraction: 0.5}
+   #- {name: "COMPASS $\\pi^-$",          file: "COMPASS_PI_MINUS_DECORR.yaml",           cuts: [{name: Qcut, min: 2.0, max: 50}],      training fraction: 0.5}
+   #- {name: "COMPASS $\\pi^+$",          file: "COMPASS_PI_PLUS_DECORR.yaml",            cuts: [{name: Qcut, min: 2.0, max: 50}],      training fraction: 0.5}
+    - {name: "BELLE $\\pi^\\pm$",         file: "BELLE_PI_PLUS_MINUS.yaml",        cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "BABAR prompt $\\pi^\\pm$",  file: "BABAR_PI_PLUS_MINUS_PROMPT.yaml", cuts: [{name: zcut, min: 0.076, max: 0.9}], training fraction: 0.5}
+    - {name: "TASSO 12 GeV $\\pi^\\pm$",  file: "TASSO_12_PI_PLUS_MINUS.yaml",     cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TASSO 14 GeV $\\pi^\\pm$",  file: "TASSO_14_PI_PLUS_MINUS.yaml",     cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TASSO 22 GeV $\\pi^\\pm$",  file: "TASSO_22_PI_PLUS_MINUS.yaml",     cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TPC $\\pi^\\pm$",           file: "TPC_PI_PLUS_MINUS.yaml",          cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TASSO 30 GeV $\\pi^\\pm$",  file: "TASSO_30_PI_PLUS_MINUS.yaml",     cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TASSO 34 GeV $\\pi^\\pm$",  file: "TASSO_34_PI_PLUS_MINUS.yaml",     cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TASSO 44 GeV $\\pi^\\pm$",  file: "TASSO_44_PI_PLUS_MINUS.yaml",     cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TOPAZ $\\pi^\\pm$",         file: "TOPAZ_PI_PLUS_MINUS.yaml",        cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "ALEPH $\\pi^\\pm$",         file: "ALEPH_PI_PLUS_MINUS.yaml",        cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+    - {name: "DELPHI total $\\pi^\\pm$",  file: "DELPHI_PI_PLUS_MINUS.yaml",       cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+    - {name: "DELPHI $uds$ $\\pi^\\pm$",  file: "DELPHI_PI_PLUS_MINUS_UDS.yaml",   cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+    - {name: "DELPHI bottom $\\pi^\\pm$", file: "DELPHI_PI_PLUS_MINUS_B.yaml",     cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+    - {name: "OPAL $\\pi^\\pm$",          file: "OPAL_PI_PLUS_MINUS.yaml",         cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+    - {name: "SLD total $\\pi^\\pm$",     file: "SLD_PI_PLUS_MINUS.yaml",          cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+    - {name: "SLD $uds$ $\\pi^\\pm$",     file: "SLD_PI_PLUS_MINUS_UDS.yaml",      cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+   #- {name: "SLD charm $\\pi^\\pm$",     file: "SLD_PI_PLUS_MINUS_C.yaml",        cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+    - {name: "SLD bottom $\\pi^\\pm$",    file: "SLD_PI_PLUS_MINUS_B.yaml",        cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}

--- a/config/HAPS-PiFF1.0-NNLO.yaml
+++ b/config/HAPS-PiFF1.0-NNLO.yaml
@@ -1,0 +1,126 @@
+#################################
+# Predictions
+#################################
+Predictions:
+  # Perturbative order, 0: LO, 1: NLO
+  perturbative order: 2
+
+  # Initial scale in GeV to be used for the DGLAP evolution of the FFs.
+  mu0: 5
+
+  # Quark thresholds
+  thresholds: [0, 0, 0, 1.51, 4.92]
+
+  # Strong coupling
+  alphas:
+    aref: 0.118
+    Qref: 91.1876
+
+  # Fine-structure constant
+  alphaem:
+    aref: 0.00776578395589
+    Qref: 91.1876
+
+  # APFEL++ grid
+  xgrid:
+    - [100, 1e-2, 3]
+    - [60,  2e-1, 3]
+    - [40,  8e-1, 3]
+
+  # PDF set
+  pdfset:
+    name: NNPDF40_nnlo_pch_as_01180
+    member: -1 #N>=0 for a specific member (0 for central) ; N<0 for all members to be used randomly(flat dist)
+
+#################################
+# Optimiser
+#################################
+# Parameters of the optimiser managed by ceres-solver
+Optimizer:
+  max_num_iterations: 3000
+  chi2_tolerance: 3
+
+#################################
+# NNAD
+#################################
+NNAD:
+  # Initialisation seed
+  seed: 0
+
+  # Architecture
+  architecture: [1, 20, 7]
+
+  # The output function can be either the activation function of the
+  # NN (0), or linear (1), or quadratic (2). If this entry is absent a
+  # linear function is assumed.
+  output function: 2
+
+  # The flavour map gives the the specific combinations of
+  # distributions in the physical-basis (d, u, s, ..) to be fitted to
+  # the data. The number of combinations has to match the number of
+  # nodes of the output layer of the NN given in the
+  # architecture. When defining the flavour map, one should keep in
+  # mind that the code computes predictions using the QCD-evolution
+  # basis (Sigma, V, T3, ...). Therefore, in general,
+  # QCD-evolution-like combinations should be preferred. Moreover, the
+  # distributions are assumed to be for the positive charge of the a
+  # given hadronic species. The negative distributions are derived
+  # using charge conjugation (q->qbar).
+
+  #             tb  bb  cb  sb  ub  db  g   d   u   s   c   b   t  # Combinations to be fitted (i.e. output of the NN):
+  flavour map: [0,  0,  0,  0,  0,  1,  0,  0,  0,  0,  0,  0,  0, # - db
+                0,  0,  0,  0,  0,  0,  1,  0,  0,  0,  0,  0,  0, # - g
+                0,  0,  0,  0,  1,  0,  0,  1,  0,  0,  0,  0,  0, # - d = ubar
+                0,  0,  0,  0,  0,  0,  0,  0,  1,  0,  0,  0,  0, # - u
+                0,  0,  0,  1,  0,  0,  0,  0,  0,  1,  0,  0,  0, # - s+
+                0,  0,  1,  0,  0,  0,  0,  0,  0,  0,  1,  0,  0, # - c+
+                0,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  1,  0] # - b+
+  combine: true
+#################################
+# Data
+#################################
+Data:
+  # Seed used for the replica generation and the splitting between
+  # training and validation (do not use a too large number here in
+  # order to avoid correlation in the replica generation).
+  seed: 2
+
+  # Hadronic species being fitted. This is used to make sure that all
+  # data sets included in the fit actually refer to the correct
+  # species.
+  hadron: PI
+
+  # Datasets to be included in the fit along with specific cuts and
+  # traning fraction. Each single dataset can implement an arbitrary
+  # number of cuts determined by the name of the appropriate function
+  # (e.g. zcut) and the allowed range.
+  sets: 
+    - {name: "COMPASS $pi^+$ 2026",          file: "COMPASS_PI_PLUS_2026.yaml",            cuts: [{name: Qcut, min: 1.5, max: 50}],      training fraction: 0.5}
+    - {name: "COMPASS $pi^-$ 2026",          file: "COMPASS_PI_MINUS_2026.yaml",           cuts: [{name: Qcut, min: 1.5, max: 50}],      training fraction: 0.5}
+    - {name: "COMPASS $pi^+$ 2025",          file: "COMPASS_PI_PLUS_2025.yaml",            cuts: [{name: Qcut, min: 1.5, max: 50}],      training fraction: 0.5}
+    - {name: "COMPASS $pi^-$ 2025",          file: "COMPASS_PI_MINUS_2025.yaml",           cuts: [{name: Qcut, min: 1.5, max: 50}],      training fraction: 0.5}
+    - {name: "HERMES $\\pi^-$ deuteron",  file: "HERMES_PI_MINUS_DEUTERON.yaml",   cuts: [{name: Qcut, min: 1.5, max: 50}, {name: zcut, min: 0.2, max: 0.8}], training fraction: 0.5}
+    - {name: "HERMES $\\pi^-$ proton",    file: "HERMES_PI_MINUS_PROTON.yaml",     cuts: [{name: Qcut, min: 1.5, max: 50}, {name: zcut, min: 0.2, max: 0.8}], training fraction: 0.5}
+    - {name: "HERMES $\\pi^+$ deuteron",  file: "HERMES_PI_PLUS_DEUTERON.yaml",    cuts: [{name: Qcut, min: 1.5, max: 50}, {name: zcut, min: 0.2, max: 0.8}], training fraction: 0.5}
+    - {name: "HERMES $\\pi^+$ proton",    file: "HERMES_PI_PLUS_PROTON.yaml",      cuts: [{name: Qcut, min: 1.5, max: 50}, {name: zcut, min: 0.2, max: 0.8}], training fraction: 0.5}
+   #- {name: "COMPASS $\\pi^-$",          file: "COMPASS_PI_MINUS_DECORR.yaml",           cuts: [{name: Qcut, min: 2.0, max: 50}],      training fraction: 0.5}
+   #- {name: "COMPASS $\\pi^+$",          file: "COMPASS_PI_PLUS_DECORR.yaml",            cuts: [{name: Qcut, min: 2.0, max: 50}],      training fraction: 0.5}
+    - {name: "BELLE $\\pi^\\pm$",         file: "BELLE_PI_PLUS_MINUS.yaml",        cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "BABAR prompt $\\pi^\\pm$",  file: "BABAR_PI_PLUS_MINUS_PROMPT.yaml", cuts: [{name: zcut, min: 0.076, max: 0.9}], training fraction: 0.5}
+    - {name: "TASSO 12 GeV $\\pi^\\pm$",  file: "TASSO_12_PI_PLUS_MINUS.yaml",     cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TASSO 14 GeV $\\pi^\\pm$",  file: "TASSO_14_PI_PLUS_MINUS.yaml",     cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TASSO 22 GeV $\\pi^\\pm$",  file: "TASSO_22_PI_PLUS_MINUS.yaml",     cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TPC $\\pi^\\pm$",           file: "TPC_PI_PLUS_MINUS.yaml",          cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TASSO 30 GeV $\\pi^\\pm$",  file: "TASSO_30_PI_PLUS_MINUS.yaml",     cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TASSO 34 GeV $\\pi^\\pm$",  file: "TASSO_34_PI_PLUS_MINUS.yaml",     cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TASSO 44 GeV $\\pi^\\pm$",  file: "TASSO_44_PI_PLUS_MINUS.yaml",     cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "TOPAZ $\\pi^\\pm$",         file: "TOPAZ_PI_PLUS_MINUS.yaml",        cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+    - {name: "ALEPH $\\pi^\\pm$",         file: "ALEPH_PI_PLUS_MINUS.yaml",        cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+    - {name: "DELPHI total $\\pi^\\pm$",  file: "DELPHI_PI_PLUS_MINUS.yaml",       cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+    - {name: "DELPHI $uds$ $\\pi^\\pm$",  file: "DELPHI_PI_PLUS_MINUS_UDS.yaml",   cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+    - {name: "DELPHI bottom $\\pi^\\pm$", file: "DELPHI_PI_PLUS_MINUS_B.yaml",     cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+    - {name: "OPAL $\\pi^\\pm$",          file: "OPAL_PI_PLUS_MINUS.yaml",         cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+    - {name: "SLD total $\\pi^\\pm$",     file: "SLD_PI_PLUS_MINUS.yaml",          cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+    - {name: "SLD $uds$ $\\pi^\\pm$",     file: "SLD_PI_PLUS_MINUS_UDS.yaml",      cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+   #- {name: "SLD charm $\\pi^\\pm$",     file: "SLD_PI_PLUS_MINUS_C.yaml",        cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+    - {name: "SLD bottom $\\pi^\\pm$",    file: "SLD_PI_PLUS_MINUS_B.yaml",        cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}

--- a/config/HAPS-hFF1.0-NLO.yaml
+++ b/config/HAPS-hFF1.0-NLO.yaml
@@ -1,0 +1,126 @@
+#
+# SHK22.h: Neural network QCD analysis of charged hadron fragmentation functions in the presence of SIDIS data,
+# Maryam Soleymaninia, Hadi Hashamipour, Hamzeh Khanpour,
+# Published in: Phys.Rev.D 105 (2022) 11, 11; 
+# e-Print: 2202.10779 [hep-ph]
+#
+#################################
+# Predictions
+#################################
+Predictions:
+  # Perturbative order, 0: LO, 1: NLO
+  perturbative order: 1
+
+  # Initial scale in GeV to be used for the DGLAP evolution of the FFs.
+  mu0: 5
+
+  # Quark thresholds
+  thresholds: [0, 0, 0, 1.51, 4.92]
+
+  # Strong coupling
+  alphas:
+    aref: 0.118
+    Qref: 91.1876
+
+  # Fine-structure constant
+  alphaem:
+    aref: 0.00776578395589
+    Qref: 91.1876
+
+  # APFEL++ grid
+  xgrid:
+    - [100, 1e-2, 3]
+    - [60,  2e-1, 3]
+    - [40,  8e-1, 3]
+
+  # PDF set
+  pdfset:
+    name: NNPDF40_nlo_pch_as_01180
+    member: -1 #N>=0 for a specific member (0 for central) ; N<0 for all members to be used randomly(flat dist)
+
+#################################
+# Optimiser
+#################################
+# Parameters of the optimiser managed by ceres-solver
+Optimizer:
+  max_num_iterations: 3000
+  chi2_tolerance: 3
+
+#################################
+# NNAD
+#################################
+NNAD:
+  # Initialisation seed
+  seed: 0
+
+  # Architecture
+  architecture: [1, 20, 7]
+
+  # The output function can be either the activation function of the
+  # NN (0), or linear (1), or quadratic (2). If this entry is absent a
+  # linear function is assumed.
+  output function: 2
+
+  # The flavour map gives the the specific combinations of
+  # distributions in the physical-basis (d, u, s, ..) to be fitted to
+  # the data. The number of combinations has to match the number of
+  # nodes of the output layer of the NN given in the
+  # architecture. When defining the flavour map, one should keep in
+  # mind that the code computes predictions using the QCD-evolution
+  # basis (Sigma, V, T3, ...). Therefore, in general,
+  # QCD-evolution-like combinations should be preferred. Moreover, the
+  # distributions are assumed to be for the positive charge of the a
+  # given hadronic species. The negative distributions are derived
+  # using charge conjugation (q->qbar).
+
+  #             tb  bb  cb  sb  ub  db  g   d   u   s   c   b   t  # Combinations to be fitted (i.e. output of the NN):
+  flavour map: [0,  0,  0,  0,  1,  0,  0,  0,  0,  0,  0,  0,  0, # - ub
+                0,  0,  0,  1,  0,  1,  0,  0,  0,  0,  0,  0,  0, # - db + sb
+                0,  0,  0,  0,  0,  0,  1,  0,  0,  0,  0,  0,  0, # - g
+                0,  0,  0,  0,  0,  0,  0,  1,  0,  1,  0,  0,  0, # - d+s
+                0,  0,  0,  0,  0,  0,  0,  0,  1,  0,  0,  0,  0, # - u
+                0,  0,  1,  0,  0,  0,  0,  0,  0,  0,  1,  0,  0, # - c+
+                0,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  1,  0] # - b+
+
+#################################
+# Data
+#################################
+Data:
+  # Seed used for the replica generation and the splitting between
+  # training and validation (do not use a too large number here in
+  # order to avoid correlation in the replica generation).
+  seed: 2
+
+  # Hadronic species being fitted. This is used to make sure that all
+  # data sets included in the fit actually refer to the correct
+  # species.
+  hadron: H
+
+  # Datasets to be included in the fit along with specific cuts and
+  # traning fraction. Each single dataset can implement an arbitrary
+  # number of cuts determined by the name of the appropriate function
+  # (e.g. zcut) and the allowed range.
+  sets:
+   - {name: "COMPASS $H^+$ 2026",          file: "COMPASS_H_PLUS_2026.yaml",            cuts: [{name: Qcut, min: 1.4, max: 50}],      training fraction: 0.5}
+   - {name: "COMPASS $H^-$ 2026",          file: "COMPASS_H_MINUS_2026.yaml",           cuts: [{name: Qcut, min: 1.4, max: 50}],      training fraction: 0.5}
+   - {name: "COMPASS $H^+$ 2025",          file: "COMPASS_H_PLUS_2025.yaml",            cuts: [{name: Qcut, min: 1.4, max: 50}],      training fraction: 0.5}
+   - {name: "COMPASS $H^-$ 2025",          file: "COMPASS_H_MINUS_2025.yaml",           cuts: [{name: Qcut, min: 1.4, max: 50}],      training fraction: 0.5}
+   #- {name: "COMPASS $H^-$",          file: "COMPASS_H_MINUS.yaml",           cuts: [{name: Qcut, min: 2.0, max: 50}],      training fraction: 0.5}
+   #- {name: "COMPASS $H^+$",          file: "COMPASS_H_PLUS.yaml",            cuts: [{name: Qcut, min: 2.0, max: 50}],      training fraction: 0.5}
+   - {name: "TASSO 14 GeV $H^\\pm$",  file: "TASSO_14_H_PLUS_MINUS.yaml",     cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+   - {name: "TASSO 22 GeV $H^\\pm$",  file: "TASSO_22_H_PLUS_MINUS.yaml",     cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+   #- {name: "TASSO 35 GeV $H^\\pm$",  file: "TASSO_35_H_PLUS_MINUS.yaml",     cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+   - {name: "TASSO 44 GeV $H^\\pm$",  file: "TASSO_44_H_PLUS_MINUS.yaml",     cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+   - {name: "TPC $H^\\pm$",           file: "TPC_H_PLUS_MINUS.yaml",          cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+   - {name: "ALEPH $H^\\pm$",             file: "ALEPH_H_PLUS_MINUS.yaml",        cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+   - {name: "DELPHI total $H^\\pm$",      file: "DELPHI_H_PLUS_MINUS.yaml",       cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+   - {name: "DELPHI $uds$ $H^\\pm$",      file: "DELPHI_H_PLUS_MINUS_UDS.yaml",   cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+   - {name: "DELPHI bottom $H^\\pm$",     file: "DELPHI_H_PLUS_MINUS_B.yaml",     cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+   - {name: "OPAL total $H^\\pm$",        file: "OPAL_H_PLUS_MINUS.yaml",         cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+   - {name: "OPAL $uds$ $H^\\pm$",        file: "OPAL_H_PLUS_MINUS_UDS.yaml",     cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+   - {name: "OPAL charm $H^\\pm$",        file: "OPAL_H_PLUS_MINUS_C.yaml",       cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+   - {name: "OPAL bottom $H^\\pm$",       file: "OPAL_H_PLUS_MINUS_B.yaml",       cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+   - {name: "SLD total $H^\\pm$",         file: "SLD_H_PLUS_MINUS.yaml",          cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+   - {name: "SLD $uds$ $H^\\pm$",         file: "SLD_H_PLUS_MINUS_UDS.yaml",      cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+   - {name: "SLD charm $H^\\pm$",         file: "SLD_H_PLUS_MINUS_C.yaml",        cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+   - {name: "SLD bottom $H^\\pm$",        file: "SLD_H_PLUS_MINUS_B.yaml",        cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}

--- a/config/HAPS-hFF1.0-NNLO.yaml
+++ b/config/HAPS-hFF1.0-NNLO.yaml
@@ -1,0 +1,126 @@
+#
+# SHK22.h: Neural network QCD analysis of charged hadron fragmentation functions in the presence of SIDIS data,
+# Maryam Soleymaninia, Hadi Hashamipour, Hamzeh Khanpour,
+# Published in: Phys.Rev.D 105 (2022) 11, 11; 
+# e-Print: 2202.10779 [hep-ph]
+#
+#################################
+# Predictions
+#################################
+Predictions:
+  # Perturbative order, 0: LO, 1: NLO
+  perturbative order: 2
+
+  # Initial scale in GeV to be used for the DGLAP evolution of the FFs.
+  mu0: 5
+
+  # Quark thresholds
+  thresholds: [0, 0, 0, 1.51, 4.92]
+
+  # Strong coupling
+  alphas:
+    aref: 0.118
+    Qref: 91.1876
+
+  # Fine-structure constant
+  alphaem:
+    aref: 0.00776578395589
+    Qref: 91.1876
+
+  # APFEL++ grid
+  xgrid:
+    - [100, 1e-2, 3]
+    - [60,  2e-1, 3]
+    - [40,  8e-1, 3]
+
+  # PDF set
+  pdfset:
+    name: NNPDF40_nnlo_pch_as_01180
+    member: -1 #N>=0 for a specific member (0 for central) ; N<0 for all members to be used randomly(flat dist)
+
+#################################
+# Optimiser
+#################################
+# Parameters of the optimiser managed by ceres-solver
+Optimizer:
+  max_num_iterations: 3000
+  chi2_tolerance: 3
+
+#################################
+# NNAD
+#################################
+NNAD:
+  # Initialisation seed
+  seed: 0
+
+  # Architecture
+  architecture: [1, 20, 7]
+
+  # The output function can be either the activation function of the
+  # NN (0), or linear (1), or quadratic (2). If this entry is absent a
+  # linear function is assumed.
+  output function: 2
+
+  # The flavour map gives the the specific combinations of
+  # distributions in the physical-basis (d, u, s, ..) to be fitted to
+  # the data. The number of combinations has to match the number of
+  # nodes of the output layer of the NN given in the
+  # architecture. When defining the flavour map, one should keep in
+  # mind that the code computes predictions using the QCD-evolution
+  # basis (Sigma, V, T3, ...). Therefore, in general,
+  # QCD-evolution-like combinations should be preferred. Moreover, the
+  # distributions are assumed to be for the positive charge of the a
+  # given hadronic species. The negative distributions are derived
+  # using charge conjugation (q->qbar).
+
+  #             tb  bb  cb  sb  ub  db  g   d   u   s   c   b   t  # Combinations to be fitted (i.e. output of the NN):
+  flavour map: [0,  0,  0,  0,  1,  0,  0,  0,  0,  0,  0,  0,  0, # - ub
+                0,  0,  0,  1,  0,  1,  0,  0,  0,  0,  0,  0,  0, # - db + sb
+                0,  0,  0,  0,  0,  0,  1,  0,  0,  0,  0,  0,  0, # - g
+                0,  0,  0,  0,  0,  0,  0,  1,  0,  1,  0,  0,  0, # - d+s
+                0,  0,  0,  0,  0,  0,  0,  0,  1,  0,  0,  0,  0, # - u
+                0,  0,  1,  0,  0,  0,  0,  0,  0,  0,  1,  0,  0, # - c+
+                0,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  1,  0] # - b+
+
+#################################
+# Data
+#################################
+Data:
+  # Seed used for the replica generation and the splitting between
+  # training and validation (do not use a too large number here in
+  # order to avoid correlation in the replica generation).
+  seed: 2
+
+  # Hadronic species being fitted. This is used to make sure that all
+  # data sets included in the fit actually refer to the correct
+  # species.
+  hadron: H
+
+  # Datasets to be included in the fit along with specific cuts and
+  # traning fraction. Each single dataset can implement an arbitrary
+  # number of cuts determined by the name of the appropriate function
+  # (e.g. zcut) and the allowed range.
+  sets:
+   - {name: "COMPASS $H^+$ 2026",          file: "COMPASS_H_PLUS_2026.yaml",            cuts: [{name: Qcut, min: 1.4, max: 50}],      training fraction: 0.5}
+   - {name: "COMPASS $H^-$ 2026",          file: "COMPASS_H_MINUS_2026.yaml",           cuts: [{name: Qcut, min: 1.4, max: 50}],      training fraction: 0.5}
+   - {name: "COMPASS $H^+$ 2025",          file: "COMPASS_H_PLUS_2025.yaml",            cuts: [{name: Qcut, min: 1.4, max: 50}],      training fraction: 0.5}
+   - {name: "COMPASS $H^-$ 2025",          file: "COMPASS_H_MINUS_2025.yaml",           cuts: [{name: Qcut, min: 1.4, max: 50}],      training fraction: 0.5}
+   #- {name: "COMPASS $H^-$",          file: "COMPASS_H_MINUS.yaml",           cuts: [{name: Qcut, min: 2.0, max: 50}],      training fraction: 0.5}
+   #- {name: "COMPASS $H^+$",          file: "COMPASS_H_PLUS.yaml",            cuts: [{name: Qcut, min: 2.0, max: 50}],      training fraction: 0.5}
+   - {name: "TASSO 14 GeV $H^\\pm$",  file: "TASSO_14_H_PLUS_MINUS.yaml",     cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+   - {name: "TASSO 22 GeV $H^\\pm$",  file: "TASSO_22_H_PLUS_MINUS.yaml",     cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+   #- {name: "TASSO 35 GeV $H^\\pm$",  file: "TASSO_35_H_PLUS_MINUS.yaml",     cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+   - {name: "TASSO 44 GeV $H^\\pm$",  file: "TASSO_44_H_PLUS_MINUS.yaml",     cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+   - {name: "TPC $H^\\pm$",           file: "TPC_H_PLUS_MINUS.yaml",          cuts: [{name: zcut, min: 0.075, max: 0.9}], training fraction: 0.5}
+   - {name: "ALEPH $H^\\pm$",             file: "ALEPH_H_PLUS_MINUS.yaml",        cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+   - {name: "DELPHI total $H^\\pm$",      file: "DELPHI_H_PLUS_MINUS.yaml",       cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+   - {name: "DELPHI $uds$ $H^\\pm$",      file: "DELPHI_H_PLUS_MINUS_UDS.yaml",   cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+   - {name: "DELPHI bottom $H^\\pm$",     file: "DELPHI_H_PLUS_MINUS_B.yaml",     cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+   - {name: "OPAL total $H^\\pm$",        file: "OPAL_H_PLUS_MINUS.yaml",         cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+   - {name: "OPAL $uds$ $H^\\pm$",        file: "OPAL_H_PLUS_MINUS_UDS.yaml",     cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+   - {name: "OPAL charm $H^\\pm$",        file: "OPAL_H_PLUS_MINUS_C.yaml",       cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+   - {name: "OPAL bottom $H^\\pm$",       file: "OPAL_H_PLUS_MINUS_B.yaml",       cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+   - {name: "SLD total $H^\\pm$",         file: "SLD_H_PLUS_MINUS.yaml",          cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+   - {name: "SLD $uds$ $H^\\pm$",         file: "SLD_H_PLUS_MINUS_UDS.yaml",      cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+   - {name: "SLD charm $H^\\pm$",         file: "SLD_H_PLUS_MINUS_C.yaml",        cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}
+   - {name: "SLD bottom $H^\\pm$",        file: "SLD_H_PLUS_MINUS_B.yaml",        cuts: [{name: zcut, min: 0.02,  max: 0.9}], training fraction: 0.5}

--- a/data/COMPASS_H_MINUS_2025.yaml
+++ b/data/COMPASS_H_MINUS_2025.yaml
@@ -1,0 +1,2440 @@
+dependent_variables:
+  - header: {title: COMPASS $H^-$ Multiplicities 2025}
+    qualifiers:
+      - {name: process, value: SIDIS}
+      - {name: observable, value: dsigma/dxdydz}
+      - {name: target_isoscalarity, value: 1.0}
+      - {name: prefactor, value: 1}
+      - {name: Vs, value: 17.35}
+      - {name: Q, low: 1, high: 7.745966692414834, integrate: true}
+      - {name: x, low: 0.004, high: 0.7, integrate: true}
+      - {name: z, low: 0.2, high: 0.85, integrate: true}
+      - {name: PS_reduction, W: 5, ymin: 0.1, ymax: 0.7}
+      - {name: hadron, value: H}
+      - {name: charge, value: -1}
+    values:
+      - errors:
+          - {label: unc, value: 0.0805}
+          - {label: add, value: 0.04026}
+        value: 2.5299
+      - errors:
+          - {label: unc, value: 0.05664}
+          - {label: add, value: 0.04035}
+        value: 1.74937
+      - errors:
+          - {label: unc, value: 0.04147}
+          - {label: add, value: 0.04083}
+        value: 1.23602
+      - errors:
+          - {label: unc, value: 0.03148}
+          - {label: add, value: 0.04134}
+        value: 0.89865
+      - errors:
+          - {label: unc, value: 0.02425}
+          - {label: add, value: 0.04255}
+        value: 0.65312
+      - errors:
+          - {label: unc, value: 0.019}
+          - {label: add, value: 0.04421}
+        value: 0.47351
+      - errors:
+          - {label: unc, value: 0.01694}
+          - {label: add, value: 0.04712}
+        value: 0.35856
+      - errors:
+          - {label: unc, value: 0.01696}
+          - {label: add, value: 0.05166}
+        value: 0.27656
+      - errors:
+          - {label: unc, value: 0.08472}
+          - {label: add, value: 0.04404}
+        value: 2.504
+      - errors:
+          - {label: unc, value: 0.05917}
+          - {label: add, value: 0.0444}
+        value: 1.71572
+      - errors:
+          - {label: unc, value: 0.04326}
+          - {label: add, value: 0.04463}
+        value: 1.22972
+      - errors:
+          - {label: unc, value: 0.03198}
+          - {label: add, value: 0.04454}
+        value: 0.86701
+      - errors:
+          - {label: unc, value: 0.02746}
+          - {label: add, value: 0.04526}
+        value: 0.63477
+      - errors:
+          - {label: unc, value: 0.03581}
+          - {label: add, value: 0.04028}
+        value: 0.64203
+      - errors:
+          - {label: unc, value: 0.02534}
+          - {label: add, value: 0.04182}
+        value: 0.50812
+      - errors:
+          - {label: unc, value: 0.02047}
+          - {label: add, value: 0.04573}
+        value: 0.36368
+      - errors:
+          - {label: unc, value: 0.01615}
+          - {label: add, value: 0.05131}
+        value: 0.24839
+      - errors:
+          - {label: unc, value: 0.01662}
+          - {label: add, value: 0.06064}
+        value: 0.23481
+      - errors:
+          - {label: unc, value: 0.01324}
+          - {label: add, value: 0.06644}
+        value: 0.16485
+      - errors:
+          - {label: unc, value: 0.01158}
+          - {label: add, value: 0.09305}
+        value: 0.11718
+      - errors:
+          - {label: unc, value: 0.00796}
+          - {label: add, value: 0.13973}
+        value: 0.0659
+      - errors:
+          - {label: unc, value: 0.03729}
+          - {label: add, value: 0.03756}
+        value: 1.2187
+      - errors:
+          - {label: unc, value: 0.02714}
+          - {label: add, value: 0.03827}
+        value: 0.8849
+      - errors:
+          - {label: unc, value: 0.02062}
+          - {label: add, value: 0.03937}
+        value: 0.6486
+      - errors:
+          - {label: unc, value: 0.01626}
+          - {label: add, value: 0.04089}
+        value: 0.48502
+      - errors:
+          - {label: unc, value: 0.01299}
+          - {label: add, value: 0.0439}
+        value: 0.3566
+      - errors:
+          - {label: unc, value: 0.01077}
+          - {label: add, value: 0.04866}
+        value: 0.26553
+      - errors:
+          - {label: unc, value: 0.00915}
+          - {label: add, value: 0.05371}
+        value: 0.20315
+      - errors:
+          - {label: unc, value: 0.00778}
+          - {label: add, value: 0.06373}
+        value: 0.14675
+      - errors:
+          - {label: unc, value: 0.00746}
+          - {label: add, value: 0.07817}
+        value: 0.11697
+      - errors:
+          - {label: unc, value: 0.00723}
+          - {label: add, value: 0.13271}
+        value: 0.07101
+      - errors:
+          - {label: unc, value: 0.07236}
+          - {label: add, value: 0.03778}
+        value: 2.47873
+      - errors:
+          - {label: unc, value: 0.04941}
+          - {label: add, value: 0.03789}
+        value: 1.70123
+      - errors:
+          - {label: unc, value: 0.03558}
+          - {label: add, value: 0.03818}
+        value: 1.20698
+      - errors:
+          - {label: unc, value: 0.026}
+          - {label: add, value: 0.03866}
+        value: 0.86231
+      - errors:
+          - {label: unc, value: 0.01949}
+          - {label: add, value: 0.03949}
+        value: 0.62543
+      - errors:
+          - {label: unc, value: 0.01511}
+          - {label: add, value: 0.04054}
+        value: 0.46586
+      - errors:
+          - {label: unc, value: 0.012}
+          - {label: add, value: 0.04295}
+        value: 0.34235
+      - errors:
+          - {label: unc, value: 0.01033}
+          - {label: add, value: 0.0468}
+        value: 0.2646
+      - errors:
+          - {label: unc, value: 0.00895}
+          - {label: add, value: 0.05187}
+        value: 0.20051
+      - errors:
+          - {label: unc, value: 0.00762}
+          - {label: add, value: 0.06032}
+        value: 0.14124
+      - errors:
+          - {label: unc, value: 0.00781}
+          - {label: add, value: 0.07768}
+        value: 0.11009
+      - errors:
+          - {label: unc, value: 0.07627}
+          - {label: add, value: 0.03998}
+        value: 2.45514
+      - errors:
+          - {label: unc, value: 0.05405}
+          - {label: add, value: 0.0403}
+        value: 1.70024
+      - errors:
+          - {label: unc, value: 0.03839}
+          - {label: add, value: 0.04057}
+        value: 1.17436
+      - errors:
+          - {label: unc, value: 0.02877}
+          - {label: add, value: 0.04075}
+        value: 0.83031
+      - errors:
+          - {label: unc, value: 0.02509}
+          - {label: add, value: 0.04102}
+        value: 0.62625
+      - errors:
+          - {label: unc, value: 0.01588}
+          - {label: add, value: 0.04891}
+        value: 0.27936
+      - errors:
+          - {label: unc, value: 0.01151}
+          - {label: add, value: 0.05282}
+        value: 0.20918
+      - errors:
+          - {label: unc, value: 0.00976}
+          - {label: add, value: 0.06318}
+        value: 0.15903
+      - errors:
+          - {label: unc, value: 0.00888}
+          - {label: add, value: 0.08514}
+        value: 0.11538
+      - errors:
+          - {label: unc, value: 0.0077}
+          - {label: add, value: 0.12257}
+        value: 0.07832
+      - errors:
+          - {label: unc, value: 0.01685}
+          - {label: add, value: 0.03934}
+        value: 0.47305
+      - errors:
+          - {label: unc, value: 0.01311}
+          - {label: add, value: 0.04225}
+        value: 0.35766
+      - errors:
+          - {label: unc, value: 0.01087}
+          - {label: add, value: 0.04638}
+        value: 0.2701
+      - errors:
+          - {label: unc, value: 0.00882}
+          - {label: add, value: 0.05048}
+        value: 0.19967
+      - errors:
+          - {label: unc, value: 0.00757}
+          - {label: add, value: 0.0585}
+        value: 0.14866
+      - errors:
+          - {label: unc, value: 0.007}
+          - {label: add, value: 0.07756}
+        value: 0.10769
+      - errors:
+          - {label: unc, value: 0.00676}
+          - {label: add, value: 0.1206}
+        value: 0.07237
+      - errors:
+          - {label: unc, value: 0.03668}
+          - {label: add, value: 0.03629}
+        value: 1.16584
+      - errors:
+          - {label: unc, value: 0.02576}
+          - {label: add, value: 0.03669}
+        value: 0.84852
+      - errors:
+          - {label: unc, value: 0.01946}
+          - {label: add, value: 0.03735}
+        value: 0.62987
+      - errors:
+          - {label: unc, value: 0.01523}
+          - {label: add, value: 0.03815}
+        value: 0.47141
+      - errors:
+          - {label: unc, value: 0.01148}
+          - {label: add, value: 0.03966}
+        value: 0.33323
+      - errors:
+          - {label: unc, value: 0.00976}
+          - {label: add, value: 0.0425}
+        value: 0.26031
+      - errors:
+          - {label: unc, value: 0.00793}
+          - {label: add, value: 0.04546}
+        value: 0.19412
+      - errors:
+          - {label: unc, value: 0.00642}
+          - {label: add, value: 0.05087}
+        value: 0.13949
+      - errors:
+          - {label: unc, value: 0.00573}
+          - {label: add, value: 0.06257}
+        value: 0.1037
+      - errors:
+          - {label: unc, value: 0.00544}
+          - {label: add, value: 0.10319}
+        value: 0.06706
+      - errors:
+          - {label: unc, value: 0.07206}
+          - {label: add, value: 0.03651}
+        value: 2.42359
+      - errors:
+          - {label: unc, value: 0.04791}
+          - {label: add, value: 0.03634}
+        value: 1.65468
+      - errors:
+          - {label: unc, value: 0.03516}
+          - {label: add, value: 0.03653}
+        value: 1.18746
+      - errors:
+          - {label: unc, value: 0.02548}
+          - {label: add, value: 0.03687}
+        value: 0.82909
+      - errors:
+          - {label: unc, value: 0.01909}
+          - {label: add, value: 0.03729}
+        value: 0.59468
+      - errors:
+          - {label: unc, value: 0.01453}
+          - {label: add, value: 0.03794}
+        value: 0.42788
+      - errors:
+          - {label: unc, value: 0.01172}
+          - {label: add, value: 0.0388}
+        value: 0.31715
+      - errors:
+          - {label: unc, value: 0.00998}
+          - {label: add, value: 0.04004}
+        value: 0.24175
+      - errors:
+          - {label: unc, value: 0.00885}
+          - {label: add, value: 0.04202}
+        value: 0.18505
+      - errors:
+          - {label: unc, value: 0.00839}
+          - {label: add, value: 0.04569}
+        value: 0.14498
+      - errors:
+          - {label: unc, value: 0.00747}
+          - {label: add, value: 0.0555}
+        value: 0.09239
+      - errors:
+          - {label: unc, value: 0.08008}
+          - {label: add, value: 0.03876}
+        value: 2.48637
+      - errors:
+          - {label: unc, value: 0.05439}
+          - {label: add, value: 0.03909}
+        value: 1.59874
+      - errors:
+          - {label: unc, value: 0.04164}
+          - {label: add, value: 0.03937}
+        value: 1.15681
+      - errors:
+          - {label: unc, value: 0.03271}
+          - {label: add, value: 0.03951}
+        value: 0.8082
+      - errors:
+          - {label: unc, value: 0.02974}
+          - {label: add, value: 0.03953}
+        value: 0.56422
+      - errors:
+          - {label: unc, value: 0.0142}
+          - {label: add, value: 0.04387}
+        value: 0.24475
+      - errors:
+          - {label: unc, value: 0.00998}
+          - {label: add, value: 0.04805}
+        value: 0.19561
+      - errors:
+          - {label: unc, value: 0.0078}
+          - {label: add, value: 0.0562}
+        value: 0.14548
+      - errors:
+          - {label: unc, value: 0.00741}
+          - {label: add, value: 0.07081}
+        value: 0.12032
+      - errors:
+          - {label: unc, value: 0.00664}
+          - {label: add, value: 0.11243}
+        value: 0.07578
+      - errors:
+          - {label: unc, value: 0.01752}
+          - {label: add, value: 0.03788}
+        value: 0.43607
+      - errors:
+          - {label: unc, value: 0.01242}
+          - {label: add, value: 0.03893}
+        value: 0.31933
+      - errors:
+          - {label: unc, value: 0.01021}
+          - {label: add, value: 0.0416}
+        value: 0.2448
+      - errors:
+          - {label: unc, value: 0.00888}
+          - {label: add, value: 0.04404}
+        value: 0.1978
+      - errors:
+          - {label: unc, value: 0.00743}
+          - {label: add, value: 0.0498}
+        value: 0.14585
+      - errors:
+          - {label: unc, value: 0.00648}
+          - {label: add, value: 0.05611}
+        value: 0.11306
+      - errors:
+          - {label: unc, value: 0.00526}
+          - {label: add, value: 0.08938}
+        value: 0.07089
+      - errors:
+          - {label: unc, value: 0.03975}
+          - {label: add, value: 0.03566}
+        value: 1.14708
+      - errors:
+          - {label: unc, value: 0.02668}
+          - {label: add, value: 0.03623}
+        value: 0.81846
+      - errors:
+          - {label: unc, value: 0.01955}
+          - {label: add, value: 0.03652}
+        value: 0.59207
+      - errors:
+          - {label: unc, value: 0.01552}
+          - {label: add, value: 0.03704}
+        value: 0.44468
+      - errors:
+          - {label: unc, value: 0.01178}
+          - {label: add, value: 0.03793}
+        value: 0.31174
+      - errors:
+          - {label: unc, value: 0.00965}
+          - {label: add, value: 0.03959}
+        value: 0.23602
+      - errors:
+          - {label: unc, value: 0.00818}
+          - {label: add, value: 0.04146}
+        value: 0.18409
+      - errors:
+          - {label: unc, value: 0.00659}
+          - {label: add, value: 0.04383}
+        value: 0.13342
+      - errors:
+          - {label: unc, value: 0.00571}
+          - {label: add, value: 0.05113}
+        value: 0.10091
+      - errors:
+          - {label: unc, value: 0.00421}
+          - {label: add, value: 0.07473}
+        value: 0.06316
+      - errors:
+          - {label: unc, value: 0.07667}
+          - {label: add, value: 0.03624}
+        value: 2.42131
+      - errors:
+          - {label: unc, value: 0.05056}
+          - {label: add, value: 0.03615}
+        value: 1.66954
+      - errors:
+          - {label: unc, value: 0.03647}
+          - {label: add, value: 0.03634}
+        value: 1.15769
+      - errors:
+          - {label: unc, value: 0.02696}
+          - {label: add, value: 0.0367}
+        value: 0.81021
+      - errors:
+          - {label: unc, value: 0.02008}
+          - {label: add, value: 0.03702}
+        value: 0.56463
+      - errors:
+          - {label: unc, value: 0.01614}
+          - {label: add, value: 0.03744}
+        value: 0.42142
+      - errors:
+          - {label: unc, value: 0.01285}
+          - {label: add, value: 0.03819}
+        value: 0.29683
+      - errors:
+          - {label: unc, value: 0.01057}
+          - {label: add, value: 0.03879}
+        value: 0.20807
+      - errors:
+          - {label: unc, value: 0.01012}
+          - {label: add, value: 0.04003}
+        value: 0.16666
+      - errors:
+          - {label: unc, value: 0.00917}
+          - {label: add, value: 0.04198}
+        value: 0.12045
+      - errors:
+          - {label: unc, value: 0.01037}
+          - {label: add, value: 0.04459}
+        value: 0.10442
+      - errors:
+          - {label: unc, value: 0.08779}
+          - {label: add, value: 0.03792}
+        value: 2.49209
+      - errors:
+          - {label: unc, value: 0.06513}
+          - {label: add, value: 0.03814}
+        value: 1.70525
+      - errors:
+          - {label: unc, value: 0.04723}
+          - {label: add, value: 0.03846}
+        value: 1.11791
+      - errors:
+          - {label: unc, value: 0.03801}
+          - {label: add, value: 0.0387}
+        value: 0.7502
+      - errors:
+          - {label: unc, value: 0.04048}
+          - {label: add, value: 0.0399}
+        value: 0.57502
+      - errors:
+          - {label: unc, value: 0.00924}
+          - {label: add, value: 0.04137}
+        value: 0.19125
+      - errors:
+          - {label: unc, value: 0.00714}
+          - {label: add, value: 0.04616}
+        value: 0.1475
+      - errors:
+          - {label: unc, value: 0.0056}
+          - {label: add, value: 0.05559}
+        value: 0.1052
+      - errors:
+          - {label: unc, value: 0.00507}
+          - {label: add, value: 0.08398}
+        value: 0.07526
+      - errors:
+          - {label: unc, value: 0.01686}
+          - {label: add, value: 0.03633}
+        value: 0.42868
+      - errors:
+          - {label: unc, value: 0.01236}
+          - {label: add, value: 0.03725}
+        value: 0.32902
+      - errors:
+          - {label: unc, value: 0.00926}
+          - {label: add, value: 0.03892}
+        value: 0.22814
+      - errors:
+          - {label: unc, value: 0.00833}
+          - {label: add, value: 0.03974}
+        value: 0.19487
+      - errors:
+          - {label: unc, value: 0.00626}
+          - {label: add, value: 0.0436}
+        value: 0.12716
+      - errors:
+          - {label: unc, value: 0.00541}
+          - {label: add, value: 0.04852}
+        value: 0.09942
+      - errors:
+          - {label: unc, value: 0.00408}
+          - {label: add, value: 0.0728}
+        value: 0.06352
+      - errors:
+          - {label: unc, value: 0.03959}
+          - {label: add, value: 0.03574}
+        value: 1.13921
+      - errors:
+          - {label: unc, value: 0.02674}
+          - {label: add, value: 0.03595}
+        value: 0.82659
+      - errors:
+          - {label: unc, value: 0.01867}
+          - {label: add, value: 0.0362}
+        value: 0.56637
+      - errors:
+          - {label: unc, value: 0.0147}
+          - {label: add, value: 0.03662}
+        value: 0.42251
+      - errors:
+          - {label: unc, value: 0.01104}
+          - {label: add, value: 0.0371}
+        value: 0.29305
+      - errors:
+          - {label: unc, value: 0.00923}
+          - {label: add, value: 0.03819}
+        value: 0.22686
+      - errors:
+          - {label: unc, value: 0.00706}
+          - {label: add, value: 0.03903}
+        value: 0.15863
+      - errors:
+          - {label: unc, value: 0.00596}
+          - {label: add, value: 0.04109}
+        value: 0.12072
+      - errors:
+          - {label: unc, value: 0.00489}
+          - {label: add, value: 0.04432}
+        value: 0.0879
+      - errors:
+          - {label: unc, value: 0.00343}
+          - {label: add, value: 0.06008}
+        value: 0.05859
+      - errors:
+          - {label: unc, value: 0.07433}
+          - {label: add, value: 0.03622}
+        value: 2.32083
+      - errors:
+          - {label: unc, value: 0.04826}
+          - {label: add, value: 0.03587}
+        value: 1.59435
+      - errors:
+          - {label: unc, value: 0.03554}
+          - {label: add, value: 0.03609}
+        value: 1.13095
+      - errors:
+          - {label: unc, value: 0.02579}
+          - {label: add, value: 0.0364}
+        value: 0.77321
+      - errors:
+          - {label: unc, value: 0.01935}
+          - {label: add, value: 0.03668}
+        value: 0.54241
+      - errors:
+          - {label: unc, value: 0.0155}
+          - {label: add, value: 0.03699}
+        value: 0.40442
+      - errors:
+          - {label: unc, value: 0.01274}
+          - {label: add, value: 0.03741}
+        value: 0.29701
+      - errors:
+          - {label: unc, value: 0.01027}
+          - {label: add, value: 0.03811}
+        value: 0.20259
+      - errors:
+          - {label: unc, value: 0.00955}
+          - {label: add, value: 0.03841}
+        value: 0.15828
+      - errors:
+          - {label: unc, value: 0.00908}
+          - {label: add, value: 0.0402}
+        value: 0.11979
+      - errors:
+          - {label: unc, value: 0.00858}
+          - {label: add, value: 0.04342}
+        value: 0.07775
+      - errors:
+          - {label: unc, value: 0.08396}
+          - {label: add, value: 0.03652}
+        value: 2.31884
+      - errors:
+          - {label: unc, value: 0.06319}
+          - {label: add, value: 0.03683}
+        value: 1.58741
+      - errors:
+          - {label: unc, value: 0.04575}
+          - {label: add, value: 0.03723}
+        value: 1.01488
+      - errors:
+          - {label: unc, value: 0.04182}
+          - {label: add, value: 0.03758}
+        value: 0.77986
+      - errors:
+          - {label: unc, value: 0.03955}
+          - {label: add, value: 0.03815}
+        value: 0.50854
+      - errors:
+          - {label: unc, value: 0.00868}
+          - {label: add, value: 0.03844}
+        value: 0.15463
+      - errors:
+          - {label: unc, value: 0.00641}
+          - {label: add, value: 0.03944}
+        value: 0.11988
+      - errors:
+          - {label: unc, value: 0.00503}
+          - {label: add, value: 0.04411}
+        value: 0.09395
+      - errors:
+          - {label: unc, value: 0.00343}
+          - {label: add, value: 0.06034}
+        value: 0.06192
+      - errors:
+          - {label: unc, value: 0.01734}
+          - {label: add, value: 0.03564}
+        value: 0.40264
+      - errors:
+          - {label: unc, value: 0.01173}
+          - {label: add, value: 0.03639}
+        value: 0.28137
+      - errors:
+          - {label: unc, value: 0.00952}
+          - {label: add, value: 0.03701}
+        value: 0.21639
+      - errors:
+          - {label: unc, value: 0.00733}
+          - {label: add, value: 0.03783}
+        value: 0.14994
+      - errors:
+          - {label: unc, value: 0.00643}
+          - {label: add, value: 0.03922}
+        value: 0.12074
+      - errors:
+          - {label: unc, value: 0.00533}
+          - {label: add, value: 0.0417}
+        value: 0.0896
+      - errors:
+          - {label: unc, value: 0.00319}
+          - {label: add, value: 0.05231}
+        value: 0.05429
+      - errors:
+          - {label: unc, value: 0.04086}
+          - {label: add, value: 0.03515}
+        value: 1.11814
+      - errors:
+          - {label: unc, value: 0.02494}
+          - {label: add, value: 0.03508}
+        value: 0.73721
+      - errors:
+          - {label: unc, value: 0.01721}
+          - {label: add, value: 0.03532}
+        value: 0.4976
+      - errors:
+          - {label: unc, value: 0.01427}
+          - {label: add, value: 0.03561}
+        value: 0.38915
+      - errors:
+          - {label: unc, value: 0.01132}
+          - {label: add, value: 0.03617}
+        value: 0.28529
+      - errors:
+          - {label: unc, value: 0.00853}
+          - {label: add, value: 0.0364}
+        value: 0.19339
+      - errors:
+          - {label: unc, value: 0.00692}
+          - {label: add, value: 0.03695}
+        value: 0.14331
+      - errors:
+          - {label: unc, value: 0.00604}
+          - {label: add, value: 0.03776}
+        value: 0.11336
+      - errors:
+          - {label: unc, value: 0.00495}
+          - {label: add, value: 0.04022}
+        value: 0.08295
+      - errors:
+          - {label: unc, value: 0.0029}
+          - {label: add, value: 0.04982}
+        value: 0.04817
+      - errors:
+          - {label: unc, value: 0.08203}
+          - {label: add, value: 0.03536}
+        value: 2.4124
+      - errors:
+          - {label: unc, value: 0.04826}
+          - {label: add, value: 0.03543}
+        value: 1.52733
+      - errors:
+          - {label: unc, value: 0.03483}
+          - {label: add, value: 0.03561}
+        value: 1.04838
+      - errors:
+          - {label: unc, value: 0.0265}
+          - {label: add, value: 0.03593}
+        value: 0.74322
+      - errors:
+          - {label: unc, value: 0.02061}
+          - {label: add, value: 0.03618}
+        value: 0.53468
+      - errors:
+          - {label: unc, value: 0.01571}
+          - {label: add, value: 0.03646}
+        value: 0.36732
+      - errors:
+          - {label: unc, value: 0.01242}
+          - {label: add, value: 0.03675}
+        value: 0.2523
+      - errors:
+          - {label: unc, value: 0.01067}
+          - {label: add, value: 0.03725}
+        value: 0.1815
+      - errors:
+          - {label: unc, value: 0.01}
+          - {label: add, value: 0.03782}
+        value: 0.13962
+      - errors:
+          - {label: unc, value: 0.01021}
+          - {label: add, value: 0.03876}
+        value: 0.1164
+      - errors:
+          - {label: unc, value: 0.00799}
+          - {label: add, value: 0.04173}
+        value: 0.0579
+      - errors:
+          - {label: unc, value: 0.09863}
+          - {label: add, value: 0.03607}
+        value: 2.34702
+      - errors:
+          - {label: unc, value: 0.07567}
+          - {label: add, value: 0.03626}
+        value: 1.5839
+      - errors:
+          - {label: unc, value: 0.06002}
+          - {label: add, value: 0.03657}
+        value: 1.10065
+      - errors:
+          - {label: unc, value: 0.05107}
+          - {label: add, value: 0.03672}
+        value: 0.74267
+      - errors:
+          - {label: unc, value: 0.05612}
+          - {label: add, value: 0.03701}
+        value: 0.55473
+      - errors:
+          - {label: unc, value: 0.01353}
+          - {label: add, value: 0.03656}
+        value: 0.14506
+      - errors:
+          - {label: unc, value: 0.00894}
+          - {label: add, value: 0.03825}
+        value: 0.09517
+      - errors:
+          - {label: unc, value: 0.00755}
+          - {label: add, value: 0.03767}
+        value: 0.08772
+      - errors:
+          - {label: unc, value: 0.00401}
+          - {label: add, value: 0.04462}
+        value: 0.05504
+      - errors:
+          - {label: unc, value: 0.02305}
+          - {label: add, value: 0.03523}
+        value: 0.34376
+      - errors:
+          - {label: unc, value: 0.01622}
+          - {label: add, value: 0.03538}
+        value: 0.26953
+      - errors:
+          - {label: unc, value: 0.01233}
+          - {label: add, value: 0.03566}
+        value: 0.18577
+      - errors:
+          - {label: unc, value: 0.01082}
+          - {label: add, value: 0.0371}
+        value: 0.14685
+      - errors:
+          - {label: unc, value: 0.00882}
+          - {label: add, value: 0.03673}
+        value: 0.1028
+      - errors:
+          - {label: unc, value: 0.00654}
+          - {label: add, value: 0.03907}
+        value: 0.06224
+      - errors:
+          - {label: unc, value: 0.00364}
+          - {label: add, value: 0.04535}
+        value: 0.03987
+      - errors:
+          - {label: unc, value: 0.04899}
+          - {label: add, value: 0.03445}
+        value: 0.93193
+      - errors:
+          - {label: unc, value: 0.03093}
+          - {label: add, value: 0.03458}
+        value: 0.69368
+      - errors:
+          - {label: unc, value: 0.022}
+          - {label: add, value: 0.03453}
+        value: 0.48142
+      - errors:
+          - {label: unc, value: 0.0171}
+          - {label: add, value: 0.03471}
+        value: 0.33094
+      - errors:
+          - {label: unc, value: 0.01385}
+          - {label: add, value: 0.03505}
+        value: 0.24037
+      - errors:
+          - {label: unc, value: 0.01111}
+          - {label: add, value: 0.03542}
+        value: 0.16669
+      - errors:
+          - {label: unc, value: 0.00949}
+          - {label: add, value: 0.03553}
+        value: 0.12856
+      - errors:
+          - {label: unc, value: 0.00755}
+          - {label: add, value: 0.03611}
+        value: 0.08464
+      - errors:
+          - {label: unc, value: 0.00675}
+          - {label: add, value: 0.03768}
+        value: 0.06901
+      - errors:
+          - {label: unc, value: 0.00379}
+          - {label: add, value: 0.04066}
+        value: 0.0423
+      - errors:
+          - {label: unc, value: 0.10709}
+          - {label: add, value: 0.03456}
+        value: 2.17635
+      - errors:
+          - {label: unc, value: 0.06194}
+          - {label: add, value: 0.03452}
+        value: 1.52421
+      - errors:
+          - {label: unc, value: 0.04464}
+          - {label: add, value: 0.03473}
+        value: 0.99401
+      - errors:
+          - {label: unc, value: 0.03422}
+          - {label: add, value: 0.03475}
+        value: 0.67034
+      - errors:
+          - {label: unc, value: 0.02755}
+          - {label: add, value: 0.03499}
+        value: 0.47306
+      - errors:
+          - {label: unc, value: 0.02249}
+          - {label: add, value: 0.03582}
+        value: 0.33096
+      - errors:
+          - {label: unc, value: 0.01752}
+          - {label: add, value: 0.03542}
+        value: 0.20981
+      - errors:
+          - {label: unc, value: 0.01782}
+          - {label: add, value: 0.03646}
+        value: 0.18302
+      - errors:
+          - {label: unc, value: 0.01582}
+          - {label: add, value: 0.03583}
+        value: 0.12681
+      - errors:
+          - {label: unc, value: 0.01323}
+          - {label: add, value: 0.03672}
+        value: 0.07735
+      - errors:
+          - {label: unc, value: 0.01643}
+          - {label: add, value: 0.03841}
+        value: 0.07539
+      - errors:
+          - {label: unc, value: 0.16292}
+          - {label: add, value: 0.03542}
+        value: 2.43022
+      - errors:
+          - {label: unc, value: 0.13236}
+          - {label: add, value: 0.03563}
+        value: 1.64305
+      - errors:
+          - {label: unc, value: 0.11273}
+          - {label: add, value: 0.03579}
+        value: 1.23214
+      - errors:
+          - {label: unc, value: 0.08572}
+          - {label: add, value: 0.03611}
+        value: 0.69993
+      - errors:
+          - {label: unc, value: 0.09131}
+          - {label: add, value: 0.03623}
+        value: 0.48469
+      - errors:
+          - {label: unc, value: 0.01954}
+          - {label: add, value: 0.03655}
+        value: 0.13438
+      - errors:
+          - {label: unc, value: 0.01509}
+          - {label: add, value: 0.03809}
+        value: 0.09913
+      - errors:
+          - {label: unc, value: 0.01199}
+          - {label: add, value: 0.03678}
+        value: 0.0844
+      - errors:
+          - {label: unc, value: 0.00562}
+          - {label: add, value: 0.04051}
+        value: 0.047
+      - errors:
+          - {label: unc, value: 0.0298}
+          - {label: add, value: 0.03478}
+        value: 0.28821
+      - errors:
+          - {label: unc, value: 0.02262}
+          - {label: add, value: 0.03539}
+        value: 0.24371
+      - errors:
+          - {label: unc, value: 0.01778}
+          - {label: add, value: 0.03527}
+        value: 0.17012
+      - errors:
+          - {label: unc, value: 0.0147}
+          - {label: add, value: 0.0356}
+        value: 0.12719
+      - errors:
+          - {label: unc, value: 0.01087}
+          - {label: add, value: 0.03606}
+        value: 0.07387
+      - errors:
+          - {label: unc, value: 0.01052}
+          - {label: add, value: 0.03694}
+        value: 0.06995
+      - errors:
+          - {label: unc, value: 0.00486}
+          - {label: add, value: 0.04065}
+        value: 0.03306
+      - errors:
+          - {label: unc, value: 0.06996}
+          - {label: add, value: 0.03426}
+        value: 0.90245
+      - errors:
+          - {label: unc, value: 0.04291}
+          - {label: add, value: 0.03446}
+        value: 0.6828
+      - errors:
+          - {label: unc, value: 0.03045}
+          - {label: add, value: 0.03479}
+        value: 0.46607
+      - errors:
+          - {label: unc, value: 0.0236}
+          - {label: add, value: 0.03523}
+        value: 0.31291
+      - errors:
+          - {label: unc, value: 0.01854}
+          - {label: add, value: 0.03579}
+        value: 0.19983
+      - errors:
+          - {label: unc, value: 0.01529}
+          - {label: add, value: 0.03537}
+        value: 0.14973
+      - errors:
+          - {label: unc, value: 0.01352}
+          - {label: add, value: 0.03765}
+        value: 0.11579
+      - errors:
+          - {label: unc, value: 0.01126}
+          - {label: add, value: 0.03635}
+        value: 0.0865
+      - errors:
+          - {label: unc, value: 0.00911}
+          - {label: add, value: 0.0399}
+        value: 0.05715
+      - errors:
+          - {label: unc, value: 0.00556}
+          - {label: add, value: 0.03918}
+        value: 0.04145
+      - errors:
+          - {label: unc, value: 0.14433}
+          - {label: add, value: 0.03455}
+        value: 1.99028
+      - errors:
+          - {label: unc, value: 0.08242}
+          - {label: add, value: 0.03445}
+        value: 1.44318
+      - errors:
+          - {label: unc, value: 0.06599}
+          - {label: add, value: 0.03441}
+        value: 1.04581
+      - errors:
+          - {label: unc, value: 0.04925}
+          - {label: add, value: 0.03452}
+        value: 0.64199
+      - errors:
+          - {label: unc, value: 0.03731}
+          - {label: add, value: 0.0347}
+        value: 0.40232
+      - errors:
+          - {label: unc, value: 0.03304}
+          - {label: add, value: 0.03539}
+        value: 0.31646
+      - errors:
+          - {label: unc, value: 0.02853}
+          - {label: add, value: 0.03502}
+        value: 0.22846
+      - errors:
+          - {label: unc, value: 0.02785}
+          - {label: add, value: 0.03607}
+        value: 0.19316
+      - errors:
+          - {label: unc, value: 0.02195}
+          - {label: add, value: 0.0354}
+        value: 0.11073
+      - errors:
+          - {label: unc, value: 0.02052}
+          - {label: add, value: 0.03859}
+        value: 0.07339
+      - errors:
+          - {label: unc, value: 0.24835}
+          - {label: add, value: 0.03654}
+        value: 2.19521
+      - errors:
+          - {label: unc, value: 0.1997}
+          - {label: add, value: 0.0364}
+        value: 1.52652
+      - errors:
+          - {label: unc, value: 0.13443}
+          - {label: add, value: 0.03773}
+        value: 0.78774
+      - errors:
+          - {label: unc, value: 0.17237}
+          - {label: add, value: 0.03647}
+        value: 0.92716
+      - errors:
+          - {label: unc, value: 0.0356}
+          - {label: add, value: 0.03515}
+        value: 0.31908
+      - errors:
+          - {label: unc, value: 0.02276}
+          - {label: add, value: 0.03479}
+        value: 0.21963
+      - errors:
+          - {label: unc, value: 0.01969}
+          - {label: add, value: 0.03519}
+        value: 0.17117
+      - errors:
+          - {label: unc, value: 0.01696}
+          - {label: add, value: 0.03513}
+        value: 0.13187
+      - errors:
+          - {label: unc, value: 0.01314}
+          - {label: add, value: 0.03629}
+        value: 0.0809
+      - errors:
+          - {label: unc, value: 0.01038}
+          - {label: add, value: 0.03585}
+        value: 0.05422
+      - errors:
+          - {label: unc, value: 0.0065}
+          - {label: add, value: 0.03783}
+        value: 0.04145
+      - errors:
+          - {label: unc, value: 0.07252}
+          - {label: add, value: 0.03468}
+        value: 0.91375
+      - errors:
+          - {label: unc, value: 0.04365}
+          - {label: add, value: 0.03422}
+        value: 0.66204
+      - errors:
+          - {label: unc, value: 0.02739}
+          - {label: add, value: 0.03445}
+        value: 0.3843
+      - errors:
+          - {label: unc, value: 0.02564}
+          - {label: add, value: 0.0347}
+        value: 0.32165
+      - errors:
+          - {label: unc, value: 0.02061}
+          - {label: add, value: 0.03469}
+        value: 0.235
+      - errors:
+          - {label: unc, value: 0.01482}
+          - {label: add, value: 0.03457}
+        value: 0.12683
+      - errors:
+          - {label: unc, value: 0.01229}
+          - {label: add, value: 0.03559}
+        value: 0.09575
+      - errors:
+          - {label: unc, value: 0.00844}
+          - {label: add, value: 0.03904}
+        value: 0.04713
+      - errors:
+          - {label: unc, value: 0.00953}
+          - {label: add, value: 0.03712}
+        value: 0.05949
+      - errors:
+          - {label: unc, value: 0.00475}
+          - {label: add, value: 0.03633}
+        value: 0.03017
+      - errors:
+          - {label: unc, value: 0.16965}
+          - {label: add, value: 0.03409}
+        value: 2.4978
+      - errors:
+          - {label: unc, value: 0.08399}
+          - {label: add, value: 0.03414}
+        value: 1.46055
+      - errors:
+          - {label: unc, value: 0.06246}
+          - {label: add, value: 0.03424}
+        value: 0.96203
+      - errors:
+          - {label: unc, value: 0.05065}
+          - {label: add, value: 0.03423}
+        value: 0.67795
+      - errors:
+          - {label: unc, value: 0.03599}
+          - {label: add, value: 0.03434}
+        value: 0.37086
+      - errors:
+          - {label: unc, value: 0.03468}
+          - {label: add, value: 0.03463}
+        value: 0.35185
+      - errors:
+          - {label: unc, value: 0.02635}
+          - {label: add, value: 0.03461}
+        value: 0.20018
+      - errors:
+          - {label: unc, value: 0.02352}
+          - {label: add, value: 0.03804}
+        value: 0.14071
+      - errors:
+          - {label: unc, value: 0.01715}
+          - {label: add, value: 0.03967}
+        value: 0.06977
+      - errors:
+          - {label: unc, value: 0.02189}
+          - {label: add, value: 0.04111}
+        value: 0.07823
+      - errors:
+          - {label: unc, value: 0.01801}
+          - {label: add, value: 0.01893}
+        value: 0.02494
+      - errors:
+          - {label: unc, value: 0.33663}
+          - {label: add, value: 0.03423}
+        value: 2.22578
+      - errors:
+          - {label: unc, value: 0.21448}
+          - {label: add, value: 0.03549}
+        value: 0.99885
+      - errors:
+          - {label: unc, value: 0.20244}
+          - {label: add, value: 0.03566}
+        value: 0.85712
+      - errors:
+          - {label: unc, value: 0.18006}
+          - {label: add, value: 0.0445}
+        value: 0.60139
+      - errors:
+          - {label: unc, value: 0.18906}
+          - {label: add, value: 0.03458}
+        value: 0.55216
+independent_variables:
+  - header: {name: z}
+    values:
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+  - header: {name: x}
+    values:
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+  - header: {name: y}
+    values:
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+  - header: {name: Q2}
+    values:
+      - {value: 0.8428630000000003}
+      - {value: 0.8428630000000003}
+      - {value: 0.8428630000000003}
+      - {value: 0.8428630000000003}
+      - {value: 0.8428630000000003}
+      - {value: 0.8428630000000003}
+      - {value: 0.8428630000000003}
+      - {value: 0.8428630000000003}
+      - {value: 1.2642945}
+      - {value: 1.2642945}
+      - {value: 1.2642945}
+      - {value: 1.2642945}
+      - {value: 1.2642945}
+      - {value: 0.7901840625000001}
+      - {value: 0.7901840625000001}
+      - {value: 0.7901840625000001}
+      - {value: 0.7901840625000001}
+      - {value: 0.7901840625000001}
+      - {value: 0.7901840625000001}
+      - {value: 0.7901840625000001}
+      - {value: 0.7901840625000001}
+      - {value: 1.128834375}
+      - {value: 1.128834375}
+      - {value: 1.128834375}
+      - {value: 1.128834375}
+      - {value: 1.128834375}
+      - {value: 1.128834375}
+      - {value: 1.128834375}
+      - {value: 1.128834375}
+      - {value: 1.128834375}
+      - {value: 1.128834375}
+      - {value: 1.8061350000000003}
+      - {value: 1.8061350000000003}
+      - {value: 1.8061350000000003}
+      - {value: 1.8061350000000003}
+      - {value: 1.8061350000000003}
+      - {value: 1.8061350000000003}
+      - {value: 1.8061350000000003}
+      - {value: 1.8061350000000003}
+      - {value: 1.8061350000000003}
+      - {value: 1.8061350000000003}
+      - {value: 1.8061350000000003}
+      - {value: 2.7092025}
+      - {value: 2.7092025}
+      - {value: 2.7092025}
+      - {value: 2.7092025}
+      - {value: 2.7092025}
+      - {value: 0.9406953125000002}
+      - {value: 0.9406953125000002}
+      - {value: 0.9406953125000002}
+      - {value: 0.9406953125000002}
+      - {value: 0.9406953125000002}
+      - {value: 1.3169734375}
+      - {value: 1.3169734375}
+      - {value: 1.3169734375}
+      - {value: 1.3169734375}
+      - {value: 1.3169734375}
+      - {value: 1.3169734375}
+      - {value: 1.3169734375}
+      - {value: 1.8813906250000003}
+      - {value: 1.8813906250000003}
+      - {value: 1.8813906250000003}
+      - {value: 1.8813906250000003}
+      - {value: 1.8813906250000003}
+      - {value: 1.8813906250000003}
+      - {value: 1.8813906250000003}
+      - {value: 1.8813906250000003}
+      - {value: 1.8813906250000003}
+      - {value: 1.8813906250000003}
+      - {value: 3.010225000000001}
+      - {value: 3.010225000000001}
+      - {value: 3.010225000000001}
+      - {value: 3.010225000000001}
+      - {value: 3.010225000000001}
+      - {value: 3.010225000000001}
+      - {value: 3.010225000000001}
+      - {value: 3.010225000000001}
+      - {value: 3.010225000000001}
+      - {value: 3.010225000000001}
+      - {value: 3.010225000000001}
+      - {value: 4.5153375}
+      - {value: 4.5153375}
+      - {value: 4.5153375}
+      - {value: 4.5153375}
+      - {value: 4.5153375}
+      - {value: 1.3169734375000002}
+      - {value: 1.3169734375000002}
+      - {value: 1.3169734375000002}
+      - {value: 1.3169734375000002}
+      - {value: 1.3169734375000002}
+      - {value: 1.8437628125000003}
+      - {value: 1.8437628125000003}
+      - {value: 1.8437628125000003}
+      - {value: 1.8437628125000003}
+      - {value: 1.8437628125000003}
+      - {value: 1.8437628125000003}
+      - {value: 1.8437628125000003}
+      - {value: 2.6339468750000004}
+      - {value: 2.6339468750000004}
+      - {value: 2.6339468750000004}
+      - {value: 2.6339468750000004}
+      - {value: 2.6339468750000004}
+      - {value: 2.6339468750000004}
+      - {value: 2.6339468750000004}
+      - {value: 2.6339468750000004}
+      - {value: 2.6339468750000004}
+      - {value: 2.6339468750000004}
+      - {value: 4.214315000000001}
+      - {value: 4.214315000000001}
+      - {value: 4.214315000000001}
+      - {value: 4.214315000000001}
+      - {value: 4.214315000000001}
+      - {value: 4.214315000000001}
+      - {value: 4.214315000000001}
+      - {value: 4.214315000000001}
+      - {value: 4.214315000000001}
+      - {value: 4.214315000000001}
+      - {value: 4.214315000000001}
+      - {value: 6.321472500000001}
+      - {value: 6.321472500000001}
+      - {value: 6.321472500000001}
+      - {value: 6.321472500000001}
+      - {value: 6.321472500000001}
+      - {value: 1.8813906250000003}
+      - {value: 1.8813906250000003}
+      - {value: 1.8813906250000003}
+      - {value: 1.8813906250000003}
+      - {value: 2.633946875}
+      - {value: 2.633946875}
+      - {value: 2.633946875}
+      - {value: 2.633946875}
+      - {value: 2.633946875}
+      - {value: 2.633946875}
+      - {value: 2.633946875}
+      - {value: 3.7627812500000006}
+      - {value: 3.7627812500000006}
+      - {value: 3.7627812500000006}
+      - {value: 3.7627812500000006}
+      - {value: 3.7627812500000006}
+      - {value: 3.7627812500000006}
+      - {value: 3.7627812500000006}
+      - {value: 3.7627812500000006}
+      - {value: 3.7627812500000006}
+      - {value: 3.7627812500000006}
+      - {value: 6.020450000000002}
+      - {value: 6.020450000000002}
+      - {value: 6.020450000000002}
+      - {value: 6.020450000000002}
+      - {value: 6.020450000000002}
+      - {value: 6.020450000000002}
+      - {value: 6.020450000000002}
+      - {value: 6.020450000000002}
+      - {value: 6.020450000000002}
+      - {value: 6.020450000000002}
+      - {value: 6.020450000000002}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 3.0102250000000006}
+      - {value: 3.0102250000000006}
+      - {value: 3.0102250000000006}
+      - {value: 3.0102250000000006}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 6.020450000000001}
+      - {value: 6.020450000000001}
+      - {value: 6.020450000000001}
+      - {value: 6.020450000000001}
+      - {value: 6.020450000000001}
+      - {value: 6.020450000000001}
+      - {value: 6.020450000000001}
+      - {value: 6.020450000000001}
+      - {value: 6.020450000000001}
+      - {value: 6.020450000000001}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 14.449080000000002}
+      - {value: 14.449080000000002}
+      - {value: 14.449080000000002}
+      - {value: 14.449080000000002}
+      - {value: 14.449080000000002}
+      - {value: 4.515337500000001}
+      - {value: 4.515337500000001}
+      - {value: 4.515337500000001}
+      - {value: 4.515337500000001}
+      - {value: 6.321472500000001}
+      - {value: 6.321472500000001}
+      - {value: 6.321472500000001}
+      - {value: 6.321472500000001}
+      - {value: 6.321472500000001}
+      - {value: 6.321472500000001}
+      - {value: 6.321472500000001}
+      - {value: 9.030675000000002}
+      - {value: 9.030675000000002}
+      - {value: 9.030675000000002}
+      - {value: 9.030675000000002}
+      - {value: 9.030675000000002}
+      - {value: 9.030675000000002}
+      - {value: 9.030675000000002}
+      - {value: 9.030675000000002}
+      - {value: 9.030675000000002}
+      - {value: 9.030675000000002}
+      - {value: 14.449080000000004}
+      - {value: 14.449080000000004}
+      - {value: 14.449080000000004}
+      - {value: 14.449080000000004}
+      - {value: 14.449080000000004}
+      - {value: 14.449080000000004}
+      - {value: 14.449080000000004}
+      - {value: 14.449080000000004}
+      - {value: 14.449080000000004}
+      - {value: 14.449080000000004}
+      - {value: 14.449080000000004}
+      - {value: 21.673620000000007}
+      - {value: 21.673620000000007}
+      - {value: 21.673620000000007}
+      - {value: 21.673620000000007}
+      - {value: 21.673620000000007}
+      - {value: 6.020450000000001}
+      - {value: 6.020450000000001}
+      - {value: 6.020450000000001}
+      - {value: 6.020450000000001}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 12.040900000000002}
+      - {value: 12.040900000000002}
+      - {value: 12.040900000000002}
+      - {value: 12.040900000000002}
+      - {value: 12.040900000000002}
+      - {value: 12.040900000000002}
+      - {value: 12.040900000000002}
+      - {value: 12.040900000000002}
+      - {value: 12.040900000000002}
+      - {value: 12.040900000000002}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 28.898160000000004}
+      - {value: 28.898160000000004}
+      - {value: 28.898160000000004}
+      - {value: 28.898160000000004}
+      - {value: 15.276891875000002}
+      - {value: 15.276891875000002}
+      - {value: 15.276891875000002}
+      - {value: 15.276891875000002}
+      - {value: 15.276891875000002}
+      - {value: 15.276891875000002}
+      - {value: 15.276891875000002}
+      - {value: 21.824131250000004}
+      - {value: 21.824131250000004}
+      - {value: 21.824131250000004}
+      - {value: 21.824131250000004}
+      - {value: 21.824131250000004}
+      - {value: 21.824131250000004}
+      - {value: 21.824131250000004}
+      - {value: 21.824131250000004}
+      - {value: 21.824131250000004}
+      - {value: 21.824131250000004}
+      - {value: 34.91861000000001}
+      - {value: 34.91861000000001}
+      - {value: 34.91861000000001}
+      - {value: 34.91861000000001}
+      - {value: 34.91861000000001}
+      - {value: 34.91861000000001}
+      - {value: 34.91861000000001}
+      - {value: 34.91861000000001}
+      - {value: 34.91861000000001}
+      - {value: 34.91861000000001}
+      - {value: 34.91861000000001}
+      - {value: 52.37791500000001}
+      - {value: 52.37791500000001}
+      - {value: 52.37791500000001}
+      - {value: 52.37791500000001}
+      - {value: 52.37791500000001}

--- a/data/COMPASS_H_MINUS_2026.yaml
+++ b/data/COMPASS_H_MINUS_2026.yaml
@@ -1,0 +1,2472 @@
+dependent_variables:
+  - header: {title: COMPASS $H^-$ Multiplicities}
+    qualifiers:
+      - {name: process, value: SIDIS}
+      - {name: observable, value: dsigma/dxdydz}
+      - {name: target_isoscalarity, value: 0.5}
+      - {name: prefactor, value: 1}
+      - {name: Vs, value: 17.35}
+      - {name: Q, low: 0.9, high: 6.0, integrate: true}
+      - {name: x, low: 0.004, high: 0.4, integrate: true}
+      - {name: z, low: 0.2, high: 0.85, integrate: true}
+      - {name: PS_reduction, W: 5, ymin: 0.1, ymax: 0.7}
+      - {name: hadron, value: H}
+      - {name: charge, value: -1}
+    values:
+      - errors:
+          - {label: unc, value: 0.06943}
+          - {label: add, value: 0.03679}
+        value: 2.4203
+      - errors:
+          - {label: unc, value: 0.04931}
+          - {label: add, value: 0.03656}
+        value: 1.7048
+      - errors:
+          - {label: unc, value: 0.03543}
+          - {label: add, value: 0.03637}
+        value: 1.201
+      - errors:
+          - {label: unc, value: 0.02632}
+          - {label: add, value: 0.03633}
+        value: 0.8655
+      - errors:
+          - {label: unc, value: 0.0213}
+          - {label: add, value: 0.03663}
+        value: 0.6726
+      - errors:
+          - {label: unc, value: 0.0166}
+          - {label: add, value: 0.03738}
+        value: 0.488
+      - errors:
+          - {label: unc, value: 0.01487}
+          - {label: add, value: 0.0389}
+        value: 0.3743
+      - errors:
+          - {label: unc, value: 0.01521}
+          - {label: add, value: 0.0411}
+        value: 0.29
+      - errors:
+          - {label: unc, value: 0.01913}
+          - {label: add, value: 0.04626}
+        value: 0.2352
+      - errors:
+          - {label: unc, value: 0.02859}
+          - {label: add, value: 0.04771}
+        value: 0.1744
+      - errors:
+          - {label: unc, value: 0.06714}
+          - {label: add, value: 0.03627}
+        value: 2.4283
+      - errors:
+          - {label: unc, value: 0.04668}
+          - {label: add, value: 0.03608}
+        value: 1.6807
+      - errors:
+          - {label: unc, value: 0.03437}
+          - {label: add, value: 0.03595}
+        value: 1.2263
+      - errors:
+          - {label: unc, value: 0.02579}
+          - {label: add, value: 0.03587}
+        value: 0.8787
+      - errors:
+          - {label: unc, value: 0.02223}
+          - {label: add, value: 0.03608}
+        value: 0.6497
+      - errors:
+          - {label: unc, value: 0.03345}
+          - {label: add, value: 0.03775}
+        value: 0.6675
+      - errors:
+          - {label: unc, value: 0.0226}
+          - {label: add, value: 0.03783}
+        value: 0.4906
+      - errors:
+          - {label: unc, value: 0.01963}
+          - {label: add, value: 0.04016}
+        value: 0.3825
+      - errors:
+          - {label: unc, value: 0.0164}
+          - {label: add, value: 0.04723}
+        value: 0.271
+      - errors:
+          - {label: unc, value: 0.01444}
+          - {label: add, value: 0.04632}
+        value: 0.2176
+      - errors:
+          - {label: unc, value: 0.01294}
+          - {label: add, value: 0.05242}
+        value: 0.1694
+      - errors:
+          - {label: unc, value: 0.0121}
+          - {label: add, value: 0.05861}
+        value: 0.1406
+      - errors:
+          - {label: unc, value: 0.00815}
+          - {label: add, value: 0.08169}
+        value: 0.0901
+      - errors:
+          - {label: unc, value: 0.03605}
+          - {label: add, value: 0.03724}
+        value: 1.2094
+      - errors:
+          - {label: unc, value: 0.02522}
+          - {label: add, value: 0.03712}
+        value: 0.8555
+      - errors:
+          - {label: unc, value: 0.01956}
+          - {label: add, value: 0.03746}
+        value: 0.6514
+      - errors:
+          - {label: unc, value: 0.01462}
+          - {label: add, value: 0.03798}
+        value: 0.4697
+      - errors:
+          - {label: unc, value: 0.01188}
+          - {label: add, value: 0.03927}
+        value: 0.3626
+      - errors:
+          - {label: unc, value: 0.01005}
+          - {label: add, value: 0.04247}
+        value: 0.2807
+      - errors:
+          - {label: unc, value: 0.00859}
+          - {label: add, value: 0.04438}
+        value: 0.2235
+      - errors:
+          - {label: unc, value: 0.00705}
+          - {label: add, value: 0.04425}
+        value: 0.179
+      - errors:
+          - {label: unc, value: 0.00669}
+          - {label: add, value: 0.05322}
+        value: 0.1428
+      - errors:
+          - {label: unc, value: 0.00557}
+          - {label: add, value: 0.07265}
+        value: 0.0947
+      - errors:
+          - {label: unc, value: 0.06781}
+          - {label: add, value: 0.03697}
+        value: 2.4062
+      - errors:
+          - {label: unc, value: 0.04709}
+          - {label: add, value: 0.03682}
+        value: 1.6815
+      - errors:
+          - {label: unc, value: 0.03385}
+          - {label: add, value: 0.03672}
+        value: 1.2049
+      - errors:
+          - {label: unc, value: 0.02487}
+          - {label: add, value: 0.03662}
+        value: 0.8804
+      - errors:
+          - {label: unc, value: 0.0179}
+          - {label: add, value: 0.0367}
+        value: 0.6256
+      - errors:
+          - {label: unc, value: 0.01386}
+          - {label: add, value: 0.03683}
+        value: 0.4757
+      - errors:
+          - {label: unc, value: 0.01077}
+          - {label: add, value: 0.03779}
+        value: 0.3514
+      - errors:
+          - {label: unc, value: 0.00919}
+          - {label: add, value: 0.03948}
+        value: 0.2776
+      - errors:
+          - {label: unc, value: 0.00782}
+          - {label: add, value: 0.04133}
+        value: 0.2129
+      - errors:
+          - {label: unc, value: 0.00717}
+          - {label: add, value: 0.04321}
+        value: 0.1722
+      - errors:
+          - {label: unc, value: 0.00686}
+          - {label: add, value: 0.05272}
+        value: 0.1214
+      - errors:
+          - {label: unc, value: 0.06673}
+          - {label: add, value: 0.03658}
+        value: 2.395
+      - errors:
+          - {label: unc, value: 0.04643}
+          - {label: add, value: 0.03646}
+        value: 1.6564
+      - errors:
+          - {label: unc, value: 0.03343}
+          - {label: add, value: 0.03632}
+        value: 1.1829
+      - errors:
+          - {label: unc, value: 0.02457}
+          - {label: add, value: 0.03621}
+        value: 0.8417
+      - errors:
+          - {label: unc, value: 0.01972}
+          - {label: add, value: 0.03627}
+        value: 0.6087
+      - errors:
+          - {label: unc, value: 0.01406}
+          - {label: add, value: 0.04721}
+        value: 0.2508
+      - errors:
+          - {label: unc, value: 0.01099}
+          - {label: add, value: 0.04344}
+        value: 0.221
+      - errors:
+          - {label: unc, value: 0.00923}
+          - {label: add, value: 0.05067}
+        value: 0.1642
+      - errors:
+          - {label: unc, value: 0.00886}
+          - {label: add, value: 0.05904}
+        value: 0.1382
+      - errors:
+          - {label: unc, value: 0.00672}
+          - {label: add, value: 0.07295}
+        value: 0.0987
+      - errors:
+          - {label: unc, value: 0.02602}
+          - {label: add, value: 0.03751}
+        value: 0.6505
+      - errors:
+          - {label: unc, value: 0.01611}
+          - {label: add, value: 0.03818}
+        value: 0.4715
+      - errors:
+          - {label: unc, value: 0.01276}
+          - {label: add, value: 0.03932}
+        value: 0.3723
+      - errors:
+          - {label: unc, value: 0.01034}
+          - {label: add, value: 0.04209}
+        value: 0.2794
+      - errors:
+          - {label: unc, value: 0.00896}
+          - {label: add, value: 0.04452}
+        value: 0.2228
+      - errors:
+          - {label: unc, value: 0.00728}
+          - {label: add, value: 0.04601}
+        value: 0.1704
+      - errors:
+          - {label: unc, value: 0.00656}
+          - {label: add, value: 0.05192}
+        value: 0.1356
+      - errors:
+          - {label: unc, value: 0.00558}
+          - {label: add, value: 0.07385}
+        value: 0.091
+      - errors:
+          - {label: unc, value: 0.03643}
+          - {label: add, value: 0.03738}
+        value: 1.1793
+      - errors:
+          - {label: unc, value: 0.0267}
+          - {label: add, value: 0.03718}
+        value: 0.8909
+      - errors:
+          - {label: unc, value: 0.01909}
+          - {label: add, value: 0.03716}
+        value: 0.633
+      - errors:
+          - {label: unc, value: 0.01452}
+          - {label: add, value: 0.03723}
+        value: 0.4684
+      - errors:
+          - {label: unc, value: 0.01122}
+          - {label: add, value: 0.03765}
+        value: 0.3485
+      - errors:
+          - {label: unc, value: 0.00931}
+          - {label: add, value: 0.03915}
+        value: 0.2718
+      - errors:
+          - {label: unc, value: 0.00742}
+          - {label: add, value: 0.04002}
+        value: 0.2039
+      - errors:
+          - {label: unc, value: 0.00626}
+          - {label: add, value: 0.04069}
+        value: 0.1632
+      - errors:
+          - {label: unc, value: 0.00534}
+          - {label: add, value: 0.04469}
+        value: 0.1253
+      - errors:
+          - {label: unc, value: 0.0047}
+          - {label: add, value: 0.06278}
+        value: 0.0892
+      - errors:
+          - {label: unc, value: 0.06907}
+          - {label: add, value: 0.03705}
+        value: 2.4053
+      - errors:
+          - {label: unc, value: 0.04784}
+          - {label: add, value: 0.03705}
+        value: 1.6754
+      - errors:
+          - {label: unc, value: 0.03391}
+          - {label: add, value: 0.03696}
+        value: 1.1775
+      - errors:
+          - {label: unc, value: 0.02487}
+          - {label: add, value: 0.03682}
+        value: 0.8538
+      - errors:
+          - {label: unc, value: 0.01855}
+          - {label: add, value: 0.03671}
+        value: 0.6254
+      - errors:
+          - {label: unc, value: 0.01386}
+          - {label: add, value: 0.03669}
+        value: 0.4557
+      - errors:
+          - {label: unc, value: 0.01075}
+          - {label: add, value: 0.03678}
+        value: 0.335
+      - errors:
+          - {label: unc, value: 0.00914}
+          - {label: add, value: 0.03773}
+        value: 0.2608
+      - errors:
+          - {label: unc, value: 0.0077}
+          - {label: add, value: 0.03769}
+        value: 0.1974
+      - errors:
+          - {label: unc, value: 0.00699}
+          - {label: add, value: 0.0397}
+        value: 0.1491
+      - errors:
+          - {label: unc, value: 0.00718}
+          - {label: add, value: 0.04315}
+        value: 0.1168
+      - errors:
+          - {label: unc, value: 0.06721}
+          - {label: add, value: 0.03683}
+        value: 2.3352
+      - errors:
+          - {label: unc, value: 0.04784}
+          - {label: add, value: 0.03668}
+        value: 1.6335
+      - errors:
+          - {label: unc, value: 0.03446}
+          - {label: add, value: 0.03654}
+        value: 1.1471
+      - errors:
+          - {label: unc, value: 0.02614}
+          - {label: add, value: 0.0365}
+        value: 0.8131
+      - errors:
+          - {label: unc, value: 0.02254}
+          - {label: add, value: 0.03644}
+        value: 0.5883
+      - errors:
+          - {label: unc, value: 0.01509}
+          - {label: add, value: 0.04173}
+        value: 0.2837
+      - errors:
+          - {label: unc, value: 0.00985}
+          - {label: add, value: 0.0431}
+        value: 0.2079
+      - errors:
+          - {label: unc, value: 0.00765}
+          - {label: add, value: 0.04532}
+        value: 0.1624
+      - errors:
+          - {label: unc, value: 0.007}
+          - {label: add, value: 0.05576}
+        value: 0.132
+      - errors:
+          - {label: unc, value: 0.00552}
+          - {label: add, value: 0.07273}
+        value: 0.0902
+      - errors:
+          - {label: unc, value: 0.02945}
+          - {label: add, value: 0.03775}
+        value: 0.6124
+      - errors:
+          - {label: unc, value: 0.01782}
+          - {label: add, value: 0.03785}
+        value: 0.4671
+      - errors:
+          - {label: unc, value: 0.01276}
+          - {label: add, value: 0.03827}
+        value: 0.3491
+      - errors:
+          - {label: unc, value: 0.01028}
+          - {label: add, value: 0.03995}
+        value: 0.2603
+      - errors:
+          - {label: unc, value: 0.00843}
+          - {label: add, value: 0.0405}
+        value: 0.2015
+      - errors:
+          - {label: unc, value: 0.00682}
+          - {label: add, value: 0.04247}
+        value: 0.1488
+      - errors:
+          - {label: unc, value: 0.00638}
+          - {label: add, value: 0.04511}
+        value: 0.1277
+      - errors:
+          - {label: unc, value: 0.00479}
+          - {label: add, value: 0.06392}
+        value: 0.0826
+      - errors:
+          - {label: unc, value: 0.03748}
+          - {label: add, value: 0.03759}
+        value: 1.164
+      - errors:
+          - {label: unc, value: 0.02635}
+          - {label: add, value: 0.03761}
+        value: 0.8424
+      - errors:
+          - {label: unc, value: 0.01965}
+          - {label: add, value: 0.03747}
+        value: 0.6235
+      - errors:
+          - {label: unc, value: 0.01482}
+          - {label: add, value: 0.0375}
+        value: 0.4523
+      - errors:
+          - {label: unc, value: 0.01113}
+          - {label: add, value: 0.03743}
+        value: 0.327
+      - errors:
+          - {label: unc, value: 0.00897}
+          - {label: add, value: 0.03781}
+        value: 0.2497
+      - errors:
+          - {label: unc, value: 0.00749}
+          - {label: add, value: 0.03847}
+        value: 0.1934
+      - errors:
+          - {label: unc, value: 0.00594}
+          - {label: add, value: 0.03897}
+        value: 0.1437
+      - errors:
+          - {label: unc, value: 0.00512}
+          - {label: add, value: 0.04248}
+        value: 0.1111
+      - errors:
+          - {label: unc, value: 0.00367}
+          - {label: add, value: 0.05206}
+        value: 0.0753
+      - errors:
+          - {label: unc, value: 0.07115}
+          - {label: add, value: 0.03748}
+        value: 2.4033
+      - errors:
+          - {label: unc, value: 0.0473}
+          - {label: add, value: 0.03748}
+        value: 1.6116
+      - errors:
+          - {label: unc, value: 0.03426}
+          - {label: add, value: 0.03738}
+        value: 1.1537
+      - errors:
+          - {label: unc, value: 0.02578}
+          - {label: add, value: 0.03727}
+        value: 0.85
+      - errors:
+          - {label: unc, value: 0.01847}
+          - {label: add, value: 0.03719}
+        value: 0.5916
+      - errors:
+          - {label: unc, value: 0.01394}
+          - {label: add, value: 0.03699}
+        value: 0.4325
+      - errors:
+          - {label: unc, value: 0.01132}
+          - {label: add, value: 0.03701}
+        value: 0.3286
+      - errors:
+          - {label: unc, value: 0.00921}
+          - {label: add, value: 0.03735}
+        value: 0.2399
+      - errors:
+          - {label: unc, value: 0.0081}
+          - {label: add, value: 0.03758}
+        value: 0.1852
+      - errors:
+          - {label: unc, value: 0.00729}
+          - {label: add, value: 0.03795}
+        value: 0.1349
+      - errors:
+          - {label: unc, value: 0.00748}
+          - {label: add, value: 0.03936}
+        value: 0.1057
+      - errors:
+          - {label: unc, value: 0.07025}
+          - {label: add, value: 0.03714}
+        value: 2.3331
+      - errors:
+          - {label: unc, value: 0.05101}
+          - {label: add, value: 0.03704}
+        value: 1.6373
+      - errors:
+          - {label: unc, value: 0.03839}
+          - {label: add, value: 0.03692}
+        value: 1.1766
+      - errors:
+          - {label: unc, value: 0.02882}
+          - {label: add, value: 0.03683}
+        value: 0.7971
+      - errors:
+          - {label: unc, value: 0.02814}
+          - {label: add, value: 0.03692}
+        value: 0.6197
+      - errors:
+          - {label: unc, value: 0.01322}
+          - {label: add, value: 0.03909}
+        value: 0.2599
+      - errors:
+          - {label: unc, value: 0.00872}
+          - {label: add, value: 0.04004}
+        value: 0.1938
+      - errors:
+          - {label: unc, value: 0.00696}
+          - {label: add, value: 0.04366}
+        value: 0.1539
+      - errors:
+          - {label: unc, value: 0.0058}
+          - {label: add, value: 0.04676}
+        value: 0.1249
+      - errors:
+          - {label: unc, value: 0.00449}
+          - {label: add, value: 0.06642}
+        value: 0.0807
+      - errors:
+          - {label: unc, value: 0.02597}
+          - {label: add, value: 0.03774}
+        value: 0.5936
+      - errors:
+          - {label: unc, value: 0.01566}
+          - {label: add, value: 0.03784}
+        value: 0.4334
+      - errors:
+          - {label: unc, value: 0.01187}
+          - {label: add, value: 0.03767}
+        value: 0.3419
+      - errors:
+          - {label: unc, value: 0.00934}
+          - {label: add, value: 0.03827}
+        value: 0.255
+      - errors:
+          - {label: unc, value: 0.00754}
+          - {label: add, value: 0.03882}
+        value: 0.1937
+      - errors:
+          - {label: unc, value: 0.0059}
+          - {label: add, value: 0.03909}
+        value: 0.1412
+      - errors:
+          - {label: unc, value: 0.00528}
+          - {label: add, value: 0.04292}
+        value: 0.1137
+      - errors:
+          - {label: unc, value: 0.00372}
+          - {label: add, value: 0.05181}
+        value: 0.0772
+      - errors:
+          - {label: unc, value: 0.03565}
+          - {label: add, value: 0.03787}
+        value: 1.1303
+      - errors:
+          - {label: unc, value: 0.02513}
+          - {label: add, value: 0.03787}
+        value: 0.8176
+      - errors:
+          - {label: unc, value: 0.01815}
+          - {label: add, value: 0.03796}
+        value: 0.5837
+      - errors:
+          - {label: unc, value: 0.01361}
+          - {label: add, value: 0.03772}
+        value: 0.4284
+      - errors:
+          - {label: unc, value: 0.01039}
+          - {label: add, value: 0.03769}
+        value: 0.3163
+      - errors:
+          - {label: unc, value: 0.00825}
+          - {label: add, value: 0.03792}
+        value: 0.2384
+      - errors:
+          - {label: unc, value: 0.00659}
+          - {label: add, value: 0.03795}
+        value: 0.1813
+      - errors:
+          - {label: unc, value: 0.00529}
+          - {label: add, value: 0.03815}
+        value: 0.1384
+      - errors:
+          - {label: unc, value: 0.00424}
+          - {label: add, value: 0.04004}
+        value: 0.0999
+      - errors:
+          - {label: unc, value: 0.00304}
+          - {label: add, value: 0.04978}
+        value: 0.0675
+      - errors:
+          - {label: unc, value: 0.06922}
+          - {label: add, value: 0.03783}
+        value: 2.3325
+      - errors:
+          - {label: unc, value: 0.04717}
+          - {label: add, value: 0.03783}
+        value: 1.6052
+      - errors:
+          - {label: unc, value: 0.03365}
+          - {label: add, value: 0.03772}
+        value: 1.1327
+      - errors:
+          - {label: unc, value: 0.02409}
+          - {label: add, value: 0.03766}
+        value: 0.7967
+      - errors:
+          - {label: unc, value: 0.0177}
+          - {label: add, value: 0.03756}
+        value: 0.5708
+      - errors:
+          - {label: unc, value: 0.01308}
+          - {label: add, value: 0.03731}
+        value: 0.4095
+      - errors:
+          - {label: unc, value: 0.01026}
+          - {label: add, value: 0.0373}
+        value: 0.3024
+      - errors:
+          - {label: unc, value: 0.00841}
+          - {label: add, value: 0.03734}
+        value: 0.2271
+      - errors:
+          - {label: unc, value: 0.00738}
+          - {label: add, value: 0.03768}
+        value: 0.1741
+      - errors:
+          - {label: unc, value: 0.00676}
+          - {label: add, value: 0.03784}
+        value: 0.1332
+      - errors:
+          - {label: unc, value: 0.00631}
+          - {label: add, value: 0.03917}
+        value: 0.0919
+      - errors:
+          - {label: unc, value: 0.07226}
+          - {label: add, value: 0.03727}
+        value: 2.3678
+      - errors:
+          - {label: unc, value: 0.04962}
+          - {label: add, value: 0.03715}
+        value: 1.5568
+      - errors:
+          - {label: unc, value: 0.03725}
+          - {label: add, value: 0.03705}
+        value: 1.112
+      - errors:
+          - {label: unc, value: 0.02834}
+          - {label: add, value: 0.03679}
+        value: 0.7588
+      - errors:
+          - {label: unc, value: 0.02645}
+          - {label: add, value: 0.03683}
+        value: 0.5626
+      - errors:
+          - {label: unc, value: 0.01186}
+          - {label: add, value: 0.0387}
+        value: 0.2398
+      - errors:
+          - {label: unc, value: 0.00765}
+          - {label: add, value: 0.03892}
+        value: 0.1747
+      - errors:
+          - {label: unc, value: 0.00577}
+          - {label: add, value: 0.04003}
+        value: 0.1319
+      - errors:
+          - {label: unc, value: 0.00455}
+          - {label: add, value: 0.04235}
+        value: 0.102
+      - errors:
+          - {label: unc, value: 0.00345}
+          - {label: add, value: 0.05427}
+        value: 0.0737
+      - errors:
+          - {label: unc, value: 0.02426}
+          - {label: add, value: 0.03831}
+        value: 0.5701
+      - errors:
+          - {label: unc, value: 0.01416}
+          - {label: add, value: 0.03797}
+        value: 0.4003
+      - errors:
+          - {label: unc, value: 0.01051}
+          - {label: add, value: 0.03788}
+        value: 0.3062
+      - errors:
+          - {label: unc, value: 0.00803}
+          - {label: add, value: 0.03803}
+        value: 0.223
+      - errors:
+          - {label: unc, value: 0.00642}
+          - {label: add, value: 0.03814}
+        value: 0.1699
+      - errors:
+          - {label: unc, value: 0.00513}
+          - {label: add, value: 0.03861}
+        value: 0.1264
+      - errors:
+          - {label: unc, value: 0.00419}
+          - {label: add, value: 0.0395}
+        value: 0.0952
+      - errors:
+          - {label: unc, value: 0.00264}
+          - {label: add, value: 0.0469}
+        value: 0.0597
+      - errors:
+          - {label: unc, value: 0.03498}
+          - {label: add, value: 0.03846}
+        value: 1.1003
+      - errors:
+          - {label: unc, value: 0.02345}
+          - {label: add, value: 0.03826}
+        value: 0.7591
+      - errors:
+          - {label: unc, value: 0.01699}
+          - {label: add, value: 0.0381}
+        value: 0.5481
+      - errors:
+          - {label: unc, value: 0.01275}
+          - {label: add, value: 0.03802}
+        value: 0.3998
+      - errors:
+          - {label: unc, value: 0.00967}
+          - {label: add, value: 0.03794}
+        value: 0.2931
+      - errors:
+          - {label: unc, value: 0.00757}
+          - {label: add, value: 0.03784}
+        value: 0.222
+      - errors:
+          - {label: unc, value: 0.0057}
+          - {label: add, value: 0.03805}
+        value: 0.1577
+      - errors:
+          - {label: unc, value: 0.00446}
+          - {label: add, value: 0.03813}
+        value: 0.1154
+      - errors:
+          - {label: unc, value: 0.00362}
+          - {label: add, value: 0.03853}
+        value: 0.0872
+      - errors:
+          - {label: unc, value: 0.00244}
+          - {label: add, value: 0.04361}
+        value: 0.0587
+      - errors:
+          - {label: unc, value: 0.07122}
+          - {label: add, value: 0.03842}
+        value: 2.3198
+      - errors:
+          - {label: unc, value: 0.04724}
+          - {label: add, value: 0.03834}
+        value: 1.5734
+      - errors:
+          - {label: unc, value: 0.03314}
+          - {label: add, value: 0.03823}
+        value: 1.0903
+      - errors:
+          - {label: unc, value: 0.02385}
+          - {label: add, value: 0.03808}
+        value: 0.7689
+      - errors:
+          - {label: unc, value: 0.01743}
+          - {label: add, value: 0.03797}
+        value: 0.5457
+      - errors:
+          - {label: unc, value: 0.01266}
+          - {label: add, value: 0.03782}
+        value: 0.3786
+      - errors:
+          - {label: unc, value: 0.01003}
+          - {label: add, value: 0.0378}
+        value: 0.2836
+      - errors:
+          - {label: unc, value: 0.00816}
+          - {label: add, value: 0.0375}
+        value: 0.2112
+      - errors:
+          - {label: unc, value: 0.00657}
+          - {label: add, value: 0.03745}
+        value: 0.1474
+      - errors:
+          - {label: unc, value: 0.00633}
+          - {label: add, value: 0.03761}
+        value: 0.117
+      - errors:
+          - {label: unc, value: 0.00575}
+          - {label: add, value: 0.03747}
+        value: 0.079
+      - errors:
+          - {label: unc, value: 0.07522}
+          - {label: add, value: 0.03798}
+        value: 2.262
+      - errors:
+          - {label: unc, value: 0.05605}
+          - {label: add, value: 0.03786}
+        value: 1.5825
+      - errors:
+          - {label: unc, value: 0.03939}
+          - {label: add, value: 0.03776}
+        value: 1.0128
+      - errors:
+          - {label: unc, value: 0.03292}
+          - {label: add, value: 0.03756}
+        value: 0.7434
+      - errors:
+          - {label: unc, value: 0.03113}
+          - {label: add, value: 0.03746}
+        value: 0.519
+      - errors:
+          - {label: unc, value: 0.01352}
+          - {label: add, value: 0.03847}
+        value: 0.2017
+      - errors:
+          - {label: unc, value: 0.00831}
+          - {label: add, value: 0.03847}
+        value: 0.1435
+      - errors:
+          - {label: unc, value: 0.0058}
+          - {label: add, value: 0.03843}
+        value: 0.102
+      - errors:
+          - {label: unc, value: 0.00494}
+          - {label: add, value: 0.04057}
+        value: 0.0907
+      - errors:
+          - {label: unc, value: 0.00297}
+          - {label: add, value: 0.04778}
+        value: 0.0586
+      - errors:
+          - {label: unc, value: 0.02649}
+          - {label: add, value: 0.03853}
+        value: 0.5004
+      - errors:
+          - {label: unc, value: 0.0153}
+          - {label: add, value: 0.03834}
+        value: 0.3735
+      - errors:
+          - {label: unc, value: 0.01093}
+          - {label: add, value: 0.03821}
+        value: 0.2743
+      - errors:
+          - {label: unc, value: 0.008}
+          - {label: add, value: 0.03838}
+        value: 0.1876
+      - errors:
+          - {label: unc, value: 0.00642}
+          - {label: add, value: 0.0382}
+        value: 0.1403
+      - errors:
+          - {label: unc, value: 0.00524}
+          - {label: add, value: 0.0385}
+        value: 0.1039
+      - errors:
+          - {label: unc, value: 0.00449}
+          - {label: add, value: 0.03931}
+        value: 0.0814
+      - errors:
+          - {label: unc, value: 0.00265}
+          - {label: add, value: 0.04567}
+        value: 0.0508
+      - errors:
+          - {label: unc, value: 0.03755}
+          - {label: add, value: 0.03887}
+        value: 1.0415
+      - errors:
+          - {label: unc, value: 0.02536}
+          - {label: add, value: 0.03853}
+        value: 0.7517
+      - errors:
+          - {label: unc, value: 0.0177}
+          - {label: add, value: 0.03831}
+        value: 0.52
+      - errors:
+          - {label: unc, value: 0.01366}
+          - {label: add, value: 0.03817}
+        value: 0.3815
+      - errors:
+          - {label: unc, value: 0.0103}
+          - {label: add, value: 0.03814}
+        value: 0.2706
+      - errors:
+          - {label: unc, value: 0.0077}
+          - {label: add, value: 0.03805}
+        value: 0.185
+      - errors:
+          - {label: unc, value: 0.00668}
+          - {label: add, value: 0.03789}
+        value: 0.152
+      - errors:
+          - {label: unc, value: 0.00516}
+          - {label: add, value: 0.03788}
+        value: 0.1056
+      - errors:
+          - {label: unc, value: 0.00423}
+          - {label: add, value: 0.03844}
+        value: 0.077
+      - errors:
+          - {label: unc, value: 0.00235}
+          - {label: add, value: 0.04089}
+        value: 0.045
+      - errors:
+          - {label: unc, value: 0.08079}
+          - {label: add, value: 0.03817}
+        value: 2.3053
+      - errors:
+          - {label: unc, value: 0.04974}
+          - {label: add, value: 0.03842}
+        value: 1.5137
+      - errors:
+          - {label: unc, value: 0.03573}
+          - {label: add, value: 0.03837}
+        value: 1.0424
+      - errors:
+          - {label: unc, value: 0.02638}
+          - {label: add, value: 0.03824}
+        value: 0.726
+      - errors:
+          - {label: unc, value: 0.01996}
+          - {label: add, value: 0.03804}
+        value: 0.5153
+      - errors:
+          - {label: unc, value: 0.0153}
+          - {label: add, value: 0.03811}
+        value: 0.3569
+      - errors:
+          - {label: unc, value: 0.01282}
+          - {label: add, value: 0.03805}
+        value: 0.2628
+      - errors:
+          - {label: unc, value: 0.01125}
+          - {label: add, value: 0.03766}
+        value: 0.2018
+      - errors:
+          - {label: unc, value: 0.00861}
+          - {label: add, value: 0.03829}
+        value: 0.1191
+      - errors:
+          - {label: unc, value: 0.00879}
+          - {label: add, value: 0.03798}
+        value: 0.1011
+      - errors:
+          - {label: unc, value: 0.00706}
+          - {label: add, value: 0.03759}
+        value: 0.0532
+      - errors:
+          - {label: unc, value: 0.10172}
+          - {label: add, value: 0.03841}
+        value: 2.2992
+      - errors:
+          - {label: unc, value: 0.07669}
+          - {label: add, value: 0.03833}
+        value: 1.5005
+      - errors:
+          - {label: unc, value: 0.06102}
+          - {label: add, value: 0.0382}
+        value: 1.0303
+      - errors:
+          - {label: unc, value: 0.05105}
+          - {label: add, value: 0.03803}
+        value: 0.7152
+      - errors:
+          - {label: unc, value: 0.05317}
+          - {label: add, value: 0.03799}
+        value: 0.4906
+      - errors:
+          - {label: unc, value: 0.01529}
+          - {label: add, value: 0.0381}
+        value: 0.1701
+      - errors:
+          - {label: unc, value: 0.01027}
+          - {label: add, value: 0.03843}
+        value: 0.1353
+      - errors:
+          - {label: unc, value: 0.00702}
+          - {label: add, value: 0.03822}
+        value: 0.0921
+      - errors:
+          - {label: unc, value: 0.006}
+          - {label: add, value: 0.03985}
+        value: 0.0803
+      - errors:
+          - {label: unc, value: 0.00315}
+          - {label: add, value: 0.04426}
+        value: 0.0488
+      - errors:
+          - {label: unc, value: 0.03182}
+          - {label: add, value: 0.03887}
+        value: 0.426
+      - errors:
+          - {label: unc, value: 0.01854}
+          - {label: add, value: 0.03886}
+        value: 0.3541
+      - errors:
+          - {label: unc, value: 0.0124}
+          - {label: add, value: 0.03845}
+        value: 0.2497
+      - errors:
+          - {label: unc, value: 0.00931}
+          - {label: add, value: 0.03852}
+        value: 0.1703
+      - errors:
+          - {label: unc, value: 0.00798}
+          - {label: add, value: 0.03858}
+        value: 0.1327
+      - errors:
+          - {label: unc, value: 0.00642}
+          - {label: add, value: 0.0381}
+        value: 0.0966
+      - errors:
+          - {label: unc, value: 0.00554}
+          - {label: add, value: 0.03924}
+        value: 0.0734
+      - errors:
+          - {label: unc, value: 0.00294}
+          - {label: add, value: 0.04201}
+        value: 0.0438
+      - errors:
+          - {label: unc, value: 0.04577}
+          - {label: add, value: 0.03917}
+        value: 1.0315
+      - errors:
+          - {label: unc, value: 0.0267}
+          - {label: add, value: 0.03887}
+        value: 0.6668
+      - errors:
+          - {label: unc, value: 0.02001}
+          - {label: add, value: 0.0386}
+        value: 0.4974
+      - errors:
+          - {label: unc, value: 0.01522}
+          - {label: add, value: 0.03847}
+        value: 0.3494
+      - errors:
+          - {label: unc, value: 0.01212}
+          - {label: add, value: 0.03832}
+        value: 0.2526
+      - errors:
+          - {label: unc, value: 0.00907}
+          - {label: add, value: 0.0383}
+        value: 0.1671
+      - errors:
+          - {label: unc, value: 0.00746}
+          - {label: add, value: 0.03867}
+        value: 0.12
+      - errors:
+          - {label: unc, value: 0.00603}
+          - {label: add, value: 0.03788}
+        value: 0.0866
+      - errors:
+          - {label: unc, value: 0.00528}
+          - {label: add, value: 0.03815}
+        value: 0.0692
+      - errors:
+          - {label: unc, value: 0.00277}
+          - {label: add, value: 0.04167}
+        value: 0.0384
+      - errors:
+          - {label: unc, value: 0.09655}
+          - {label: add, value: 0.03855}
+        value: 2.2244
+      - errors:
+          - {label: unc, value: 0.05863}
+          - {label: add, value: 0.03879}
+        value: 1.52
+      - errors:
+          - {label: unc, value: 0.04108}
+          - {label: add, value: 0.03868}
+        value: 0.9784
+      - errors:
+          - {label: unc, value: 0.03281}
+          - {label: add, value: 0.03858}
+        value: 0.7133
+      - errors:
+          - {label: unc, value: 0.02463}
+          - {label: add, value: 0.03845}
+        value: 0.4682
+      - errors:
+          - {label: unc, value: 0.02279}
+          - {label: add, value: 0.03831}
+        value: 0.3926
+      - errors:
+          - {label: unc, value: 0.01745}
+          - {label: add, value: 0.03822}
+        value: 0.2512
+      - errors:
+          - {label: unc, value: 0.01477}
+          - {label: add, value: 0.03794}
+        value: 0.175
+      - errors:
+          - {label: unc, value: 0.01251}
+          - {label: add, value: 0.03799}
+        value: 0.1116
+      - errors:
+          - {label: unc, value: 0.01203}
+          - {label: add, value: 0.03805}
+        value: 0.082
+      - errors:
+          - {label: unc, value: 0.01335}
+          - {label: add, value: 0.03934}
+        value: 0.0671
+      - errors:
+          - {label: unc, value: 0.03582}
+          - {label: add, value: 0.03901}
+        value: 0.4676
+      - errors:
+          - {label: unc, value: 0.01893}
+          - {label: add, value: 0.03894}
+        value: 0.341
+      - errors:
+          - {label: unc, value: 0.0132}
+          - {label: add, value: 0.03867}
+        value: 0.2462
+      - errors:
+          - {label: unc, value: 0.00976}
+          - {label: add, value: 0.03853}
+        value: 0.1661
+      - errors:
+          - {label: unc, value: 0.00811}
+          - {label: add, value: 0.03853}
+        value: 0.1225
+      - errors:
+          - {label: unc, value: 0.00683}
+          - {label: add, value: 0.03818}
+        value: 0.0922
+      - errors:
+          - {label: unc, value: 0.00531}
+          - {label: add, value: 0.03934}
+        value: 0.061
+      - errors:
+          - {label: unc, value: 0.00261}
+          - {label: add, value: 0.04096}
+        value: 0.0332
+      - errors:
+          - {label: unc, value: 0.04549}
+          - {label: add, value: 0.03969}
+        value: 0.9513
+      - errors:
+          - {label: unc, value: 0.02718}
+          - {label: add, value: 0.03941}
+        value: 0.6475
+      - errors:
+          - {label: unc, value: 0.01936}
+          - {label: add, value: 0.0391}
+        value: 0.4522
+      - errors:
+          - {label: unc, value: 0.01487}
+          - {label: add, value: 0.03914}
+        value: 0.3168
+      - errors:
+          - {label: unc, value: 0.0119}
+          - {label: add, value: 0.03889}
+        value: 0.2263
+      - errors:
+          - {label: unc, value: 0.00953}
+          - {label: add, value: 0.03876}
+        value: 0.1672
+      - errors:
+          - {label: unc, value: 0.00819}
+          - {label: add, value: 0.03857}
+        value: 0.1286
+      - errors:
+          - {label: unc, value: 0.00584}
+          - {label: add, value: 0.03829}
+        value: 0.0773
+      - errors:
+          - {label: unc, value: 0.00499}
+          - {label: add, value: 0.03882}
+        value: 0.0577
+      - errors:
+          - {label: unc, value: 0.00247}
+          - {label: add, value: 0.0396}
+        value: 0.0303
+      - errors:
+          - {label: unc, value: 0.10091}
+          - {label: add, value: 0.03879}
+        value: 2.2132
+      - errors:
+          - {label: unc, value: 0.05626}
+          - {label: add, value: 0.03887}
+        value: 1.4325
+      - errors:
+          - {label: unc, value: 0.04153}
+          - {label: add, value: 0.03888}
+        value: 0.9816
+      - errors:
+          - {label: unc, value: 0.03079}
+          - {label: add, value: 0.03877}
+        value: 0.6459
+      - errors:
+          - {label: unc, value: 0.0245}
+          - {label: add, value: 0.03863}
+        value: 0.4577
+      - errors:
+          - {label: unc, value: 0.02095}
+          - {label: add, value: 0.03844}
+        value: 0.3538
+      - errors:
+          - {label: unc, value: 0.0159}
+          - {label: add, value: 0.0383}
+        value: 0.2193
+      - errors:
+          - {label: unc, value: 0.01311}
+          - {label: add, value: 0.0381}
+        value: 0.1491
+      - errors:
+          - {label: unc, value: 0.01285}
+          - {label: add, value: 0.038}
+        value: 0.1179
+      - errors:
+          - {label: unc, value: 0.01072}
+          - {label: add, value: 0.0384}
+        value: 0.075
+independent_variables:
+  - header: {name: z}
+    values:
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+  - header: {name: x}
+    values:
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+  - header: {name: y}
+    values:
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+  - header: {name: Q2}
+    values:
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}

--- a/data/COMPASS_H_PLUS_2025.yaml
+++ b/data/COMPASS_H_PLUS_2025.yaml
@@ -1,0 +1,2440 @@
+dependent_variables:
+  - header: {title: COMPASS $H^+$ Multiplicities 2025}
+    qualifiers:
+      - {name: process, value: SIDIS}
+      - {name: observable, value: dsigma/dxdydz}
+      - {name: target_isoscalarity, value: 1.0}
+      - {name: prefactor, value: 1}
+      - {name: Vs, value: 17.35}
+      - {name: Q, low: 1, high: 7.745966692414834, integrate: true}
+      - {name: x, low: 0.004, high: 0.7, integrate: true}
+      - {name: z, low: 0.2, high: 0.85, integrate: true}
+      - {name: PS_reduction, W: 5, ymin: 0.1, ymax: 0.7}
+      - {name: hadron, value: H}
+      - {name: charge, value: 1}
+    values:
+      - errors:
+          - {label: unc, value: 0.08948}
+          - {label: add, value: 0.04008}
+        value: 2.8375
+      - errors:
+          - {label: unc, value: 0.06394}
+          - {label: add, value: 0.04011}
+        value: 2.00036
+      - errors:
+          - {label: unc, value: 0.04852}
+          - {label: add, value: 0.04043}
+        value: 1.47656
+      - errors:
+          - {label: unc, value: 0.03621}
+          - {label: add, value: 0.04096}
+        value: 1.05874
+      - errors:
+          - {label: unc, value: 0.02884}
+          - {label: add, value: 0.04182}
+        value: 0.80566
+      - errors:
+          - {label: unc, value: 0.02263}
+          - {label: add, value: 0.04289}
+        value: 0.59335
+      - errors:
+          - {label: unc, value: 0.02079}
+          - {label: add, value: 0.04519}
+        value: 0.4755
+      - errors:
+          - {label: unc, value: 0.01932}
+          - {label: add, value: 0.05258}
+        value: 0.33201
+      - errors:
+          - {label: unc, value: 0.09339}
+          - {label: add, value: 0.044}
+        value: 2.76824
+      - errors:
+          - {label: unc, value: 0.06729}
+          - {label: add, value: 0.04425}
+        value: 1.96504
+      - errors:
+          - {label: unc, value: 0.04963}
+          - {label: add, value: 0.0444}
+        value: 1.4261
+      - errors:
+          - {label: unc, value: 0.0378}
+          - {label: add, value: 0.04411}
+        value: 1.04812
+      - errors:
+          - {label: unc, value: 0.03288}
+          - {label: add, value: 0.04443}
+        value: 0.79843
+      - errors:
+          - {label: unc, value: 0.04149}
+          - {label: add, value: 0.03914}
+        value: 0.80291
+      - errors:
+          - {label: unc, value: 0.02986}
+          - {label: add, value: 0.04026}
+        value: 0.65416
+      - errors:
+          - {label: unc, value: 0.02484}
+          - {label: add, value: 0.04157}
+        value: 0.49753
+      - errors:
+          - {label: unc, value: 0.02226}
+          - {label: add, value: 0.0459}
+        value: 0.40731
+      - errors:
+          - {label: unc, value: 0.01889}
+          - {label: add, value: 0.04836}
+        value: 0.31349
+      - errors:
+          - {label: unc, value: 0.01623}
+          - {label: add, value: 0.05835}
+        value: 0.23364
+      - errors:
+          - {label: unc, value: 0.01469}
+          - {label: add, value: 0.07544}
+        value: 0.17847
+      - errors:
+          - {label: unc, value: 0.01056}
+          - {label: add, value: 0.1184}
+        value: 0.10372
+      - errors:
+          - {label: unc, value: 0.04546}
+          - {label: add, value: 0.03718}
+        value: 1.52056
+      - errors:
+          - {label: unc, value: 0.0337}
+          - {label: add, value: 0.03762}
+        value: 1.12969
+      - errors:
+          - {label: unc, value: 0.02611}
+          - {label: add, value: 0.03849}
+        value: 0.85088
+      - errors:
+          - {label: unc, value: 0.02031}
+          - {label: add, value: 0.03954}
+        value: 0.63485
+      - errors:
+          - {label: unc, value: 0.01659}
+          - {label: add, value: 0.04174}
+        value: 0.48629
+      - errors:
+          - {label: unc, value: 0.01399}
+          - {label: add, value: 0.04521}
+        value: 0.37623
+      - errors:
+          - {label: unc, value: 0.01165}
+          - {label: add, value: 0.04863}
+        value: 0.28874
+      - errors:
+          - {label: unc, value: 0.00943}
+          - {label: add, value: 0.05351}
+        value: 0.21064
+      - errors:
+          - {label: unc, value: 0.00935}
+          - {label: add, value: 0.07043}
+        value: 0.16356
+      - errors:
+          - {label: unc, value: 0.00871}
+          - {label: add, value: 0.10969}
+        value: 0.10327
+      - errors:
+          - {label: unc, value: 0.08131}
+          - {label: add, value: 0.03754}
+        value: 2.81132
+      - errors:
+          - {label: unc, value: 0.05799}
+          - {label: add, value: 0.03756}
+        value: 2.01955
+      - errors:
+          - {label: unc, value: 0.0423}
+          - {label: add, value: 0.0378}
+        value: 1.45539
+      - errors:
+          - {label: unc, value: 0.03224}
+          - {label: add, value: 0.03818}
+        value: 1.08981
+      - errors:
+          - {label: unc, value: 0.02431}
+          - {label: add, value: 0.03884}
+        value: 0.79996
+      - errors:
+          - {label: unc, value: 0.01885}
+          - {label: add, value: 0.03969}
+        value: 0.59987
+      - errors:
+          - {label: unc, value: 0.01542}
+          - {label: add, value: 0.04135}
+        value: 0.46315
+      - errors:
+          - {label: unc, value: 0.0127}
+          - {label: add, value: 0.04412}
+        value: 0.34906
+      - errors:
+          - {label: unc, value: 0.01101}
+          - {label: add, value: 0.04806}
+        value: 0.27017
+      - errors:
+          - {label: unc, value: 0.00987}
+          - {label: add, value: 0.05227}
+        value: 0.21214
+      - errors:
+          - {label: unc, value: 0.00943}
+          - {label: add, value: 0.06349}
+        value: 0.15864
+      - errors:
+          - {label: unc, value: 0.08615}
+          - {label: add, value: 0.03984}
+        value: 2.79292
+      - errors:
+          - {label: unc, value: 0.06125}
+          - {label: add, value: 0.0401}
+        value: 1.94615
+      - errors:
+          - {label: unc, value: 0.04528}
+          - {label: add, value: 0.04033}
+        value: 1.40639
+      - errors:
+          - {label: unc, value: 0.03535}
+          - {label: add, value: 0.04035}
+        value: 1.04977
+      - errors:
+          - {label: unc, value: 0.03025}
+          - {label: add, value: 0.04051}
+        value: 0.79375
+      - errors:
+          - {label: unc, value: 0.01978}
+          - {label: add, value: 0.04332}
+        value: 0.40554
+      - errors:
+          - {label: unc, value: 0.01513}
+          - {label: add, value: 0.0478}
+        value: 0.317
+      - errors:
+          - {label: unc, value: 0.01239}
+          - {label: add, value: 0.04937}
+        value: 0.25276
+      - errors:
+          - {label: unc, value: 0.01064}
+          - {label: add, value: 0.06186}
+        value: 0.18234
+      - errors:
+          - {label: unc, value: 0.0092}
+          - {label: add, value: 0.09155}
+        value: 0.12347
+      - errors:
+          - {label: unc, value: 0.02163}
+          - {label: add, value: 0.03776}
+        value: 0.65277
+      - errors:
+          - {label: unc, value: 0.01669}
+          - {label: add, value: 0.03961}
+        value: 0.49649
+      - errors:
+          - {label: unc, value: 0.01388}
+          - {label: add, value: 0.04238}
+        value: 0.38472
+      - errors:
+          - {label: unc, value: 0.01154}
+          - {label: add, value: 0.0452}
+        value: 0.29611
+      - errors:
+          - {label: unc, value: 0.01018}
+          - {label: add, value: 0.04898}
+        value: 0.23995
+      - errors:
+          - {label: unc, value: 0.00883}
+          - {label: add, value: 0.05752}
+        value: 0.17929
+      - errors:
+          - {label: unc, value: 0.00811}
+          - {label: add, value: 0.08602}
+        value: 0.12034
+      - errors:
+          - {label: unc, value: 0.04503}
+          - {label: add, value: 0.03592}
+        value: 1.47932
+      - errors:
+          - {label: unc, value: 0.03349}
+          - {label: add, value: 0.03617}
+        value: 1.14097
+      - errors:
+          - {label: unc, value: 0.02483}
+          - {label: add, value: 0.03663}
+        value: 0.83469
+      - errors:
+          - {label: unc, value: 0.01967}
+          - {label: add, value: 0.03728}
+        value: 0.63814
+      - errors:
+          - {label: unc, value: 0.01582}
+          - {label: add, value: 0.03838}
+        value: 0.48936
+      - errors:
+          - {label: unc, value: 0.01291}
+          - {label: add, value: 0.03987}
+        value: 0.37686
+      - errors:
+          - {label: unc, value: 0.01036}
+          - {label: add, value: 0.04197}
+        value: 0.28194
+      - errors:
+          - {label: unc, value: 0.00874}
+          - {label: add, value: 0.04507}
+        value: 0.21868
+      - errors:
+          - {label: unc, value: 0.00766}
+          - {label: add, value: 0.05294}
+        value: 0.16503
+      - errors:
+          - {label: unc, value: 0.00665}
+          - {label: add, value: 0.07916}
+        value: 0.10581
+      - errors:
+          - {label: unc, value: 0.08397}
+          - {label: add, value: 0.03621}
+        value: 2.87411
+      - errors:
+          - {label: unc, value: 0.05767}
+          - {label: add, value: 0.036}
+        value: 2.02781
+      - errors:
+          - {label: unc, value: 0.04249}
+          - {label: add, value: 0.03618}
+        value: 1.46597
+      - errors:
+          - {label: unc, value: 0.03214}
+          - {label: add, value: 0.0365}
+        value: 1.07636
+      - errors:
+          - {label: unc, value: 0.02498}
+          - {label: add, value: 0.03683}
+        value: 0.8096
+      - errors:
+          - {label: unc, value: 0.01904}
+          - {label: add, value: 0.03728}
+        value: 0.59012
+      - errors:
+          - {label: unc, value: 0.01543}
+          - {label: add, value: 0.03794}
+        value: 0.44723
+      - errors:
+          - {label: unc, value: 0.01332}
+          - {label: add, value: 0.03903}
+        value: 0.35149
+      - errors:
+          - {label: unc, value: 0.01202}
+          - {label: add, value: 0.04037}
+        value: 0.28123
+      - errors:
+          - {label: unc, value: 0.01027}
+          - {label: add, value: 0.0434}
+        value: 0.19924
+      - errors:
+          - {label: unc, value: 0.01025}
+          - {label: add, value: 0.05401}
+        value: 0.14754
+      - errors:
+          - {label: unc, value: 0.08872}
+          - {label: add, value: 0.03854}
+        value: 2.79498
+      - errors:
+          - {label: unc, value: 0.06468}
+          - {label: add, value: 0.03887}
+        value: 1.94902
+      - errors:
+          - {label: unc, value: 0.05015}
+          - {label: add, value: 0.03913}
+        value: 1.44337
+      - errors:
+          - {label: unc, value: 0.04042}
+          - {label: add, value: 0.03923}
+        value: 1.05313
+      - errors:
+          - {label: unc, value: 0.03734}
+          - {label: add, value: 0.03928}
+        value: 0.77318
+      - errors:
+          - {label: unc, value: 0.01928}
+          - {label: add, value: 0.04031}
+        value: 0.39869
+      - errors:
+          - {label: unc, value: 0.01365}
+          - {label: add, value: 0.04146}
+        value: 0.32108
+      - errors:
+          - {label: unc, value: 0.01077}
+          - {label: add, value: 0.04528}
+        value: 0.25051
+      - errors:
+          - {label: unc, value: 0.0091}
+          - {label: add, value: 0.05228}
+        value: 0.19464
+      - errors:
+          - {label: unc, value: 0.00783}
+          - {label: add, value: 0.07415}
+        value: 0.13314
+      - errors:
+          - {label: unc, value: 0.02405}
+          - {label: add, value: 0.03681}
+        value: 0.66771
+      - errors:
+          - {label: unc, value: 0.01723}
+          - {label: add, value: 0.03771}
+        value: 0.49048
+      - errors:
+          - {label: unc, value: 0.01463}
+          - {label: add, value: 0.03888}
+        value: 0.39918
+      - errors:
+          - {label: unc, value: 0.01171}
+          - {label: add, value: 0.04062}
+        value: 0.29583
+      - errors:
+          - {label: unc, value: 0.01029}
+          - {label: add, value: 0.04293}
+        value: 0.24189
+      - errors:
+          - {label: unc, value: 0.0087}
+          - {label: add, value: 0.0469}
+        value: 0.18558
+      - errors:
+          - {label: unc, value: 0.00693}
+          - {label: add, value: 0.06615}
+        value: 0.1242
+      - errors:
+          - {label: unc, value: 0.04878}
+          - {label: add, value: 0.03519}
+        value: 1.48581
+      - errors:
+          - {label: unc, value: 0.03456}
+          - {label: add, value: 0.03561}
+        value: 1.11892
+      - errors:
+          - {label: unc, value: 0.02664}
+          - {label: add, value: 0.03593}
+        value: 0.85599
+      - errors:
+          - {label: unc, value: 0.02034}
+          - {label: add, value: 0.0364}
+        value: 0.62202
+      - errors:
+          - {label: unc, value: 0.01643}
+          - {label: add, value: 0.03692}
+        value: 0.47696
+      - errors:
+          - {label: unc, value: 0.01306}
+          - {label: add, value: 0.03801}
+        value: 0.3532
+      - errors:
+          - {label: unc, value: 0.01093}
+          - {label: add, value: 0.03927}
+        value: 0.27662
+      - errors:
+          - {label: unc, value: 0.00977}
+          - {label: add, value: 0.04098}
+        value: 0.23033
+      - errors:
+          - {label: unc, value: 0.00775}
+          - {label: add, value: 0.04644}
+        value: 0.16004
+      - errors:
+          - {label: unc, value: 0.0058}
+          - {label: add, value: 0.05899}
+        value: 0.11012
+      - errors:
+          - {label: unc, value: 0.0888}
+          - {label: add, value: 0.03591}
+        value: 2.88187
+      - errors:
+          - {label: unc, value: 0.06071}
+          - {label: add, value: 0.03575}
+        value: 2.05744
+      - errors:
+          - {label: unc, value: 0.04498}
+          - {label: add, value: 0.03595}
+        value: 1.47876
+      - errors:
+          - {label: unc, value: 0.03469}
+          - {label: add, value: 0.03624}
+        value: 1.09368
+      - errors:
+          - {label: unc, value: 0.02765}
+          - {label: add, value: 0.03656}
+        value: 0.83213
+      - errors:
+          - {label: unc, value: 0.02135}
+          - {label: add, value: 0.03694}
+        value: 0.6036
+      - errors:
+          - {label: unc, value: 0.01816}
+          - {label: add, value: 0.03737}
+        value: 0.47176
+      - errors:
+          - {label: unc, value: 0.01498}
+          - {label: add, value: 0.03795}
+        value: 0.34111
+      - errors:
+          - {label: unc, value: 0.01439}
+          - {label: add, value: 0.03865}
+        value: 0.28726
+      - errors:
+          - {label: unc, value: 0.01363}
+          - {label: add, value: 0.04011}
+        value: 0.21841
+      - errors:
+          - {label: unc, value: 0.0137}
+          - {label: add, value: 0.04192}
+        value: 0.16717
+      - errors:
+          - {label: unc, value: 0.10145}
+          - {label: add, value: 0.03767}
+        value: 2.96956
+      - errors:
+          - {label: unc, value: 0.07642}
+          - {label: add, value: 0.03793}
+        value: 2.08911
+      - errors:
+          - {label: unc, value: 0.05863}
+          - {label: add, value: 0.03823}
+        value: 1.4755
+      - errors:
+          - {label: unc, value: 0.05136}
+          - {label: add, value: 0.03845}
+        value: 1.13558
+      - errors:
+          - {label: unc, value: 0.04792}
+          - {label: add, value: 0.039}
+        value: 0.75177
+      - errors:
+          - {label: unc, value: 0.0128}
+          - {label: add, value: 0.0381}
+        value: 0.31117
+      - errors:
+          - {label: unc, value: 0.00945}
+          - {label: add, value: 0.04003}
+        value: 0.233
+      - errors:
+          - {label: unc, value: 0.00783}
+          - {label: add, value: 0.04484}
+        value: 0.18449
+      - errors:
+          - {label: unc, value: 0.00641}
+          - {label: add, value: 0.05859}
+        value: 0.13421
+      - errors:
+          - {label: unc, value: 0.02266}
+          - {label: add, value: 0.03566}
+        value: 0.63755
+      - errors:
+          - {label: unc, value: 0.01692}
+          - {label: add, value: 0.0362}
+        value: 0.49629
+      - errors:
+          - {label: unc, value: 0.01395}
+          - {label: add, value: 0.03697}
+        value: 0.3941
+      - errors:
+          - {label: unc, value: 0.01144}
+          - {label: add, value: 0.03787}
+        value: 0.30273
+      - errors:
+          - {label: unc, value: 0.00944}
+          - {label: add, value: 0.03931}
+        value: 0.2324
+      - errors:
+          - {label: unc, value: 0.00791}
+          - {label: add, value: 0.04234}
+        value: 0.17686
+      - errors:
+          - {label: unc, value: 0.00546}
+          - {label: add, value: 0.05376}
+        value: 0.11325
+      - errors:
+          - {label: unc, value: 0.05017}
+          - {label: add, value: 0.03529}
+        value: 1.5326
+      - errors:
+          - {label: unc, value: 0.03462}
+          - {label: add, value: 0.03543}
+        value: 1.12634
+      - errors:
+          - {label: unc, value: 0.02574}
+          - {label: add, value: 0.03565}
+        value: 0.83122
+      - errors:
+          - {label: unc, value: 0.02059}
+          - {label: add, value: 0.03598}
+        value: 0.63833
+      - errors:
+          - {label: unc, value: 0.01643}
+          - {label: add, value: 0.03643}
+        value: 0.48507
+      - errors:
+          - {label: unc, value: 0.01345}
+          - {label: add, value: 0.037}
+        value: 0.37466
+      - errors:
+          - {label: unc, value: 0.01104}
+          - {label: add, value: 0.03774}
+        value: 0.28805
+      - errors:
+          - {label: unc, value: 0.00928}
+          - {label: add, value: 0.03899}
+        value: 0.22551
+      - errors:
+          - {label: unc, value: 0.0073}
+          - {label: add, value: 0.04074}
+        value: 0.15966
+      - errors:
+          - {label: unc, value: 0.00513}
+          - {label: add, value: 0.05014}
+        value: 0.10801
+      - errors:
+          - {label: unc, value: 0.09152}
+          - {label: add, value: 0.03576}
+        value: 2.96419
+      - errors:
+          - {label: unc, value: 0.06111}
+          - {label: add, value: 0.03545}
+        value: 2.08707
+      - errors:
+          - {label: unc, value: 0.04484}
+          - {label: add, value: 0.03565}
+        value: 1.48504
+      - errors:
+          - {label: unc, value: 0.03498}
+          - {label: add, value: 0.03594}
+        value: 1.1127
+      - errors:
+          - {label: unc, value: 0.02753}
+          - {label: add, value: 0.03623}
+        value: 0.83482
+      - errors:
+          - {label: unc, value: 0.02145}
+          - {label: add, value: 0.03652}
+        value: 0.61144
+      - errors:
+          - {label: unc, value: 0.01715}
+          - {label: add, value: 0.03684}
+        value: 0.44538
+      - errors:
+          - {label: unc, value: 0.01514}
+          - {label: add, value: 0.03722}
+        value: 0.35311
+      - errors:
+          - {label: unc, value: 0.014}
+          - {label: add, value: 0.03752}
+        value: 0.28227
+      - errors:
+          - {label: unc, value: 0.01268}
+          - {label: add, value: 0.03805}
+        value: 0.20459
+      - errors:
+          - {label: unc, value: 0.01297}
+          - {label: add, value: 0.03955}
+        value: 0.15637
+      - errors:
+          - {label: unc, value: 0.09723}
+          - {label: add, value: 0.03631}
+        value: 2.78828
+      - errors:
+          - {label: unc, value: 0.07586}
+          - {label: add, value: 0.03658}
+        value: 2.00883
+      - errors:
+          - {label: unc, value: 0.06271}
+          - {label: add, value: 0.03681}
+        value: 1.54142
+      - errors:
+          - {label: unc, value: 0.05021}
+          - {label: add, value: 0.03728}
+        value: 1.03315
+      - errors:
+          - {label: unc, value: 0.05223}
+          - {label: add, value: 0.03794}
+        value: 0.78395
+      - errors:
+          - {label: unc, value: 0.01326}
+          - {label: add, value: 0.0368}
+        value: 0.29783
+      - errors:
+          - {label: unc, value: 0.0102}
+          - {label: add, value: 0.03737}
+        value: 0.24084
+      - errors:
+          - {label: unc, value: 0.00771}
+          - {label: add, value: 0.03913}
+        value: 0.17973
+      - errors:
+          - {label: unc, value: 0.00547}
+          - {label: add, value: 0.04569}
+        value: 0.13237
+      - errors:
+          - {label: unc, value: 0.02416}
+          - {label: add, value: 0.03511}
+        value: 0.63896
+      - errors:
+          - {label: unc, value: 0.01775}
+          - {label: add, value: 0.03566}
+        value: 0.49339
+      - errors:
+          - {label: unc, value: 0.0141}
+          - {label: add, value: 0.03604}
+        value: 0.3749
+      - errors:
+          - {label: unc, value: 0.01155}
+          - {label: add, value: 0.03663}
+        value: 0.28745
+      - errors:
+          - {label: unc, value: 0.00962}
+          - {label: add, value: 0.03742}
+        value: 0.22299
+      - errors:
+          - {label: unc, value: 0.00823}
+          - {label: add, value: 0.0385}
+        value: 0.17662
+      - errors:
+          - {label: unc, value: 0.00533}
+          - {label: add, value: 0.04341}
+        value: 0.1185
+      - errors:
+          - {label: unc, value: 0.05177}
+          - {label: add, value: 0.03469}
+        value: 1.53097
+      - errors:
+          - {label: unc, value: 0.03533}
+          - {label: add, value: 0.03472}
+        value: 1.13038
+      - errors:
+          - {label: unc, value: 0.02704}
+          - {label: add, value: 0.03489}
+        value: 0.86228
+      - errors:
+          - {label: unc, value: 0.02215}
+          - {label: add, value: 0.0351}
+        value: 0.67777
+      - errors:
+          - {label: unc, value: 0.01661}
+          - {label: add, value: 0.0354}
+        value: 0.47616
+      - errors:
+          - {label: unc, value: 0.01373}
+          - {label: add, value: 0.03575}
+        value: 0.37082
+      - errors:
+          - {label: unc, value: 0.01088}
+          - {label: add, value: 0.03615}
+        value: 0.26957
+      - errors:
+          - {label: unc, value: 0.00969}
+          - {label: add, value: 0.03672}
+        value: 0.22615
+      - errors:
+          - {label: unc, value: 0.00785}
+          - {label: add, value: 0.03781}
+        value: 0.16715
+      - errors:
+          - {label: unc, value: 0.00492}
+          - {label: add, value: 0.04162}
+        value: 0.10765
+      - errors:
+          - {label: unc, value: 0.09834}
+          - {label: add, value: 0.03495}
+        value: 3.02964
+      - errors:
+          - {label: unc, value: 0.06257}
+          - {label: add, value: 0.03502}
+        value: 2.07368
+      - errors:
+          - {label: unc, value: 0.04864}
+          - {label: add, value: 0.03517}
+        value: 1.56277
+      - errors:
+          - {label: unc, value: 0.03693}
+          - {label: add, value: 0.03541}
+        value: 1.12438
+      - errors:
+          - {label: unc, value: 0.03039}
+          - {label: add, value: 0.03572}
+        value: 0.87756
+      - errors:
+          - {label: unc, value: 0.02321}
+          - {label: add, value: 0.036}
+        value: 0.62111
+      - errors:
+          - {label: unc, value: 0.01972}
+          - {label: add, value: 0.0363}
+        value: 0.47981
+      - errors:
+          - {label: unc, value: 0.01731}
+          - {label: add, value: 0.03705}
+        value: 0.36941
+      - errors:
+          - {label: unc, value: 0.01501}
+          - {label: add, value: 0.03751}
+        value: 0.26723
+      - errors:
+          - {label: unc, value: 0.01475}
+          - {label: add, value: 0.03783}
+        value: 0.21719
+      - errors:
+          - {label: unc, value: 0.01508}
+          - {label: add, value: 0.03873}
+        value: 0.16276
+      - errors:
+          - {label: unc, value: 0.11318}
+          - {label: add, value: 0.03574}
+        value: 2.84133
+      - errors:
+          - {label: unc, value: 0.08872}
+          - {label: add, value: 0.03596}
+        value: 2.00865
+      - errors:
+          - {label: unc, value: 0.07434}
+          - {label: add, value: 0.03633}
+        value: 1.51568
+      - errors:
+          - {label: unc, value: 0.07083}
+          - {label: add, value: 0.03725}
+        value: 1.21474
+      - errors:
+          - {label: unc, value: 0.06789}
+          - {label: add, value: 0.03712}
+        value: 0.80636
+      - errors:
+          - {label: unc, value: 0.02008}
+          - {label: add, value: 0.03626}
+        value: 0.29055
+      - errors:
+          - {label: unc, value: 0.01479}
+          - {label: add, value: 0.03608}
+        value: 0.23168
+      - errors:
+          - {label: unc, value: 0.01225}
+          - {label: add, value: 0.03617}
+        value: 0.19594
+      - errors:
+          - {label: unc, value: 0.00694}
+          - {label: add, value: 0.03865}
+        value: 0.13434
+      - errors:
+          - {label: unc, value: 0.03172}
+          - {label: add, value: 0.03476}
+        value: 0.60301
+      - errors:
+          - {label: unc, value: 0.02468}
+          - {label: add, value: 0.03485}
+        value: 0.52504
+      - errors:
+          - {label: unc, value: 0.01949}
+          - {label: add, value: 0.03522}
+        value: 0.38474
+      - errors:
+          - {label: unc, value: 0.0162}
+          - {label: add, value: 0.03548}
+        value: 0.28748
+      - errors:
+          - {label: unc, value: 0.01357}
+          - {label: add, value: 0.03573}
+        value: 0.21651
+      - errors:
+          - {label: unc, value: 0.01219}
+          - {label: add, value: 0.03665}
+        value: 0.17792
+      - errors:
+          - {label: unc, value: 0.00702}
+          - {label: add, value: 0.03853}
+        value: 0.11834
+      - errors:
+          - {label: unc, value: 0.07024}
+          - {label: add, value: 0.03415}
+        value: 1.58253
+      - errors:
+          - {label: unc, value: 0.04358}
+          - {label: add, value: 0.03409}
+        value: 1.14113
+      - errors:
+          - {label: unc, value: 0.0327}
+          - {label: add, value: 0.03423}
+        value: 0.85472
+      - errors:
+          - {label: unc, value: 0.02676}
+          - {label: add, value: 0.03438}
+        value: 0.64684
+      - errors:
+          - {label: unc, value: 0.02201}
+          - {label: add, value: 0.03455}
+        value: 0.48766
+      - errors:
+          - {label: unc, value: 0.01877}
+          - {label: add, value: 0.0348}
+        value: 0.38479
+      - errors:
+          - {label: unc, value: 0.01505}
+          - {label: add, value: 0.03515}
+        value: 0.27583
+      - errors:
+          - {label: unc, value: 0.01328}
+          - {label: add, value: 0.03581}
+        value: 0.21804
+      - errors:
+          - {label: unc, value: 0.01083}
+          - {label: add, value: 0.03574}
+        value: 0.15871
+      - errors:
+          - {label: unc, value: 0.00609}
+          - {label: add, value: 0.03788}
+        value: 0.09651
+      - errors:
+          - {label: unc, value: 0.13286}
+          - {label: add, value: 0.03425}
+        value: 3.01079
+      - errors:
+          - {label: unc, value: 0.07917}
+          - {label: add, value: 0.03418}
+        value: 2.14527
+      - errors:
+          - {label: unc, value: 0.062}
+          - {label: add, value: 0.03435}
+        value: 1.57436
+      - errors:
+          - {label: unc, value: 0.04969}
+          - {label: add, value: 0.03442}
+        value: 1.15758
+      - errors:
+          - {label: unc, value: 0.04016}
+          - {label: add, value: 0.03461}
+        value: 0.84303
+      - errors:
+          - {label: unc, value: 0.03369}
+          - {label: add, value: 0.03531}
+        value: 0.63135
+      - errors:
+          - {label: unc, value: 0.02918}
+          - {label: add, value: 0.03508}
+        value: 0.4819
+      - errors:
+          - {label: unc, value: 0.02639}
+          - {label: add, value: 0.03542}
+        value: 0.37127
+      - errors:
+          - {label: unc, value: 0.02398}
+          - {label: add, value: 0.0365}
+        value: 0.26456
+      - errors:
+          - {label: unc, value: 0.02419}
+          - {label: add, value: 0.03574}
+        value: 0.22563
+      - errors:
+          - {label: unc, value: 0.02727}
+          - {label: add, value: 0.03676}
+        value: 0.18478
+      - errors:
+          - {label: unc, value: 0.19556}
+          - {label: add, value: 0.03507}
+        value: 3.22626
+      - errors:
+          - {label: unc, value: 0.15864}
+          - {label: add, value: 0.03578}
+        value: 2.25062
+      - errors:
+          - {label: unc, value: 0.13411}
+          - {label: add, value: 0.03566}
+        value: 1.69359
+      - errors:
+          - {label: unc, value: 0.11515}
+          - {label: add, value: 0.0359}
+        value: 1.15012
+      - errors:
+          - {label: unc, value: 0.12881}
+          - {label: add, value: 0.03619}
+        value: 0.89322
+      - errors:
+          - {label: unc, value: 0.03629}
+          - {label: add, value: 0.03495}
+        value: 0.38019
+      - errors:
+          - {label: unc, value: 0.02689}
+          - {label: add, value: 0.0357}
+        value: 0.28595
+      - errors:
+          - {label: unc, value: 0.01861}
+          - {label: add, value: 0.03568}
+        value: 0.18787
+      - errors:
+          - {label: unc, value: 0.01004}
+          - {label: add, value: 0.03684}
+        value: 0.12248
+      - errors:
+          - {label: unc, value: 0.05157}
+          - {label: add, value: 0.03429}
+        value: 0.72656
+      - errors:
+          - {label: unc, value: 0.03484}
+          - {label: add, value: 0.03499}
+        value: 0.51853
+      - errors:
+          - {label: unc, value: 0.02617}
+          - {label: add, value: 0.03473}
+        value: 0.34946
+      - errors:
+          - {label: unc, value: 0.02529}
+          - {label: add, value: 0.03584}
+        value: 0.31472
+      - errors:
+          - {label: unc, value: 0.01994}
+          - {label: add, value: 0.0352}
+        value: 0.21366
+      - errors:
+          - {label: unc, value: 0.01834}
+          - {label: add, value: 0.03564}
+        value: 0.18295
+      - errors:
+          - {label: unc, value: 0.00962}
+          - {label: add, value: 0.03679}
+        value: 0.10503
+      - errors:
+          - {label: unc, value: 0.09303}
+          - {label: add, value: 0.03409}
+        value: 1.45601
+      - errors:
+          - {label: unc, value: 0.05769}
+          - {label: add, value: 0.03412}
+        value: 1.1087
+      - errors:
+          - {label: unc, value: 0.04306}
+          - {label: add, value: 0.03442}
+        value: 0.83409
+      - errors:
+          - {label: unc, value: 0.03721}
+          - {label: add, value: 0.03457}
+        value: 0.66293
+      - errors:
+          - {label: unc, value: 0.03162}
+          - {label: add, value: 0.03472}
+        value: 0.50685
+      - errors:
+          - {label: unc, value: 0.02741}
+          - {label: add, value: 0.03499}
+        value: 0.4026
+      - errors:
+          - {label: unc, value: 0.02127}
+          - {label: add, value: 0.03763}
+        value: 0.27127
+      - errors:
+          - {label: unc, value: 0.01956}
+          - {label: add, value: 0.03547}
+        value: 0.23186
+      - errors:
+          - {label: unc, value: 0.01477}
+          - {label: add, value: 0.03675}
+        value: 0.14388
+      - errors:
+          - {label: unc, value: 0.00913}
+          - {label: add, value: 0.03748}
+        value: 0.10074
+      - errors:
+          - {label: unc, value: 0.2007}
+          - {label: add, value: 0.03441}
+        value: 3.23348
+      - errors:
+          - {label: unc, value: 0.10342}
+          - {label: add, value: 0.03454}
+        value: 2.03292
+      - errors:
+          - {label: unc, value: 0.0845}
+          - {label: add, value: 0.03412}
+        value: 1.55738
+      - errors:
+          - {label: unc, value: 0.0707}
+          - {label: add, value: 0.03424}
+        value: 1.16802
+      - errors:
+          - {label: unc, value: 0.05894}
+          - {label: add, value: 0.0347}
+        value: 0.85722
+      - errors:
+          - {label: unc, value: 0.05023}
+          - {label: add, value: 0.03453}
+        value: 0.65448
+      - errors:
+          - {label: unc, value: 0.05074}
+          - {label: add, value: 0.03468}
+        value: 0.59814
+      - errors:
+          - {label: unc, value: 0.03984}
+          - {label: add, value: 0.03594}
+        value: 0.36509
+      - errors:
+          - {label: unc, value: 0.03978}
+          - {label: add, value: 0.03604}
+        value: 0.30236
+      - errors:
+          - {label: unc, value: 0.0375}
+          - {label: add, value: 0.0395}
+        value: 0.20519
+      - errors:
+          - {label: unc, value: 0.28481}
+          - {label: add, value: 0.03525}
+        value: 2.9889
+      - errors:
+          - {label: unc, value: 0.2505}
+          - {label: add, value: 0.0354}
+        value: 2.20269
+      - errors:
+          - {label: unc, value: 0.20279}
+          - {label: add, value: 0.03632}
+        value: 1.49331
+      - errors:
+          - {label: unc, value: 0.2025}
+          - {label: add, value: 0.03669}
+        value: 1.31136
+      - errors:
+          - {label: unc, value: 0.05559}
+          - {label: add, value: 0.03452}
+        value: 0.72405
+      - errors:
+          - {label: unc, value: 0.03563}
+          - {label: add, value: 0.0343}
+        value: 0.47998
+      - errors:
+          - {label: unc, value: 0.028}
+          - {label: add, value: 0.03467}
+        value: 0.33643
+      - errors:
+          - {label: unc, value: 0.02919}
+          - {label: add, value: 0.03465}
+        value: 0.34058
+      - errors:
+          - {label: unc, value: 0.02569}
+          - {label: add, value: 0.03483}
+        value: 0.27842
+      - errors:
+          - {label: unc, value: 0.02327}
+          - {label: add, value: 0.03508}
+        value: 0.21733
+      - errors:
+          - {label: unc, value: 0.01285}
+          - {label: add, value: 0.03568}
+        value: 0.13766
+      - errors:
+          - {label: unc, value: 0.10422}
+          - {label: add, value: 0.03404}
+        value: 1.64455
+      - errors:
+          - {label: unc, value: 0.06043}
+          - {label: add, value: 0.03402}
+        value: 1.16711
+      - errors:
+          - {label: unc, value: 0.04568}
+          - {label: add, value: 0.03473}
+        value: 0.85812
+      - errors:
+          - {label: unc, value: 0.0356}
+          - {label: add, value: 0.03431}
+        value: 0.59963
+      - errors:
+          - {label: unc, value: 0.03233}
+          - {label: add, value: 0.03415}
+        value: 0.50387
+      - errors:
+          - {label: unc, value: 0.02893}
+          - {label: add, value: 0.03441}
+        value: 0.41015
+      - errors:
+          - {label: unc, value: 0.02383}
+          - {label: add, value: 0.03515}
+        value: 0.30955
+      - errors:
+          - {label: unc, value: 0.01999}
+          - {label: add, value: 0.03552}
+        value: 0.22117
+      - errors:
+          - {label: unc, value: 0.0168}
+          - {label: add, value: 0.03507}
+        value: 0.17088
+      - errors:
+          - {label: unc, value: 0.00931}
+          - {label: add, value: 0.03616}
+        value: 0.09978
+      - errors:
+          - {label: unc, value: 0.18629}
+          - {label: add, value: 0.03437}
+        value: 2.94082
+      - errors:
+          - {label: unc, value: 0.10725}
+          - {label: add, value: 0.03395}
+        value: 2.16952
+      - errors:
+          - {label: unc, value: 0.08115}
+          - {label: add, value: 0.03406}
+        value: 1.4962
+      - errors:
+          - {label: unc, value: 0.07347}
+          - {label: add, value: 0.03407}
+        value: 1.26803
+      - errors:
+          - {label: unc, value: 0.0638}
+          - {label: add, value: 0.0341}
+        value: 1.01015
+      - errors:
+          - {label: unc, value: 0.05347}
+          - {label: add, value: 0.03435}
+        value: 0.74453
+      - errors:
+          - {label: unc, value: 0.04483}
+          - {label: add, value: 0.03483}
+        value: 0.50417
+      - errors:
+          - {label: unc, value: 0.03712}
+          - {label: add, value: 0.03448}
+        value: 0.34824
+      - errors:
+          - {label: unc, value: 0.03852}
+          - {label: add, value: 0.03493}
+        value: 0.31169
+      - errors:
+          - {label: unc, value: 0.03402}
+          - {label: add, value: 0.03626}
+        value: 0.19988
+      - errors:
+          - {label: unc, value: 0.03532}
+          - {label: add, value: 0.03971}
+        value: 0.13175
+      - errors:
+          - {label: unc, value: 0.43139}
+          - {label: add, value: 0.03515}
+        value: 3.31044
+      - errors:
+          - {label: unc, value: 0.31289}
+          - {label: add, value: 0.03485}
+        value: 2.01807
+      - errors:
+          - {label: unc, value: 0.25153}
+          - {label: add, value: 0.03432}
+        value: 1.36687
+      - errors:
+          - {label: unc, value: 0.28887}
+          - {label: add, value: 0.03545}
+        value: 1.39129
+      - errors:
+          - {label: unc, value: 0.14773}
+          - {label: add, value: 0.04775}
+        value: 0.34013
+independent_variables:
+  - header: {name: z}
+    values:
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.32499999999999996}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.42500000000000004}
+  - header: {name: x}
+    values:
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.14, low: 0.1, value: 0.12000000000000001}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+      - {high: 0.4, low: 0.18, value: 0.29000000000000004}
+  - header: {name: y}
+    values:
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+  - header: {name: Q2}
+    values:
+      - {value: 0.8428630000000003}
+      - {value: 0.8428630000000003}
+      - {value: 0.8428630000000003}
+      - {value: 0.8428630000000003}
+      - {value: 0.8428630000000003}
+      - {value: 0.8428630000000003}
+      - {value: 0.8428630000000003}
+      - {value: 0.8428630000000003}
+      - {value: 1.2642945}
+      - {value: 1.2642945}
+      - {value: 1.2642945}
+      - {value: 1.2642945}
+      - {value: 1.2642945}
+      - {value: 0.7901840625000001}
+      - {value: 0.7901840625000001}
+      - {value: 0.7901840625000001}
+      - {value: 0.7901840625000001}
+      - {value: 0.7901840625000001}
+      - {value: 0.7901840625000001}
+      - {value: 0.7901840625000001}
+      - {value: 0.7901840625000001}
+      - {value: 1.128834375}
+      - {value: 1.128834375}
+      - {value: 1.128834375}
+      - {value: 1.128834375}
+      - {value: 1.128834375}
+      - {value: 1.128834375}
+      - {value: 1.128834375}
+      - {value: 1.128834375}
+      - {value: 1.128834375}
+      - {value: 1.128834375}
+      - {value: 1.8061350000000003}
+      - {value: 1.8061350000000003}
+      - {value: 1.8061350000000003}
+      - {value: 1.8061350000000003}
+      - {value: 1.8061350000000003}
+      - {value: 1.8061350000000003}
+      - {value: 1.8061350000000003}
+      - {value: 1.8061350000000003}
+      - {value: 1.8061350000000003}
+      - {value: 1.8061350000000003}
+      - {value: 1.8061350000000003}
+      - {value: 2.7092025}
+      - {value: 2.7092025}
+      - {value: 2.7092025}
+      - {value: 2.7092025}
+      - {value: 2.7092025}
+      - {value: 0.9406953125000002}
+      - {value: 0.9406953125000002}
+      - {value: 0.9406953125000002}
+      - {value: 0.9406953125000002}
+      - {value: 0.9406953125000002}
+      - {value: 1.3169734375}
+      - {value: 1.3169734375}
+      - {value: 1.3169734375}
+      - {value: 1.3169734375}
+      - {value: 1.3169734375}
+      - {value: 1.3169734375}
+      - {value: 1.3169734375}
+      - {value: 1.8813906250000003}
+      - {value: 1.8813906250000003}
+      - {value: 1.8813906250000003}
+      - {value: 1.8813906250000003}
+      - {value: 1.8813906250000003}
+      - {value: 1.8813906250000003}
+      - {value: 1.8813906250000003}
+      - {value: 1.8813906250000003}
+      - {value: 1.8813906250000003}
+      - {value: 1.8813906250000003}
+      - {value: 3.010225000000001}
+      - {value: 3.010225000000001}
+      - {value: 3.010225000000001}
+      - {value: 3.010225000000001}
+      - {value: 3.010225000000001}
+      - {value: 3.010225000000001}
+      - {value: 3.010225000000001}
+      - {value: 3.010225000000001}
+      - {value: 3.010225000000001}
+      - {value: 3.010225000000001}
+      - {value: 3.010225000000001}
+      - {value: 4.5153375}
+      - {value: 4.5153375}
+      - {value: 4.5153375}
+      - {value: 4.5153375}
+      - {value: 4.5153375}
+      - {value: 1.3169734375000002}
+      - {value: 1.3169734375000002}
+      - {value: 1.3169734375000002}
+      - {value: 1.3169734375000002}
+      - {value: 1.3169734375000002}
+      - {value: 1.8437628125000003}
+      - {value: 1.8437628125000003}
+      - {value: 1.8437628125000003}
+      - {value: 1.8437628125000003}
+      - {value: 1.8437628125000003}
+      - {value: 1.8437628125000003}
+      - {value: 1.8437628125000003}
+      - {value: 2.6339468750000004}
+      - {value: 2.6339468750000004}
+      - {value: 2.6339468750000004}
+      - {value: 2.6339468750000004}
+      - {value: 2.6339468750000004}
+      - {value: 2.6339468750000004}
+      - {value: 2.6339468750000004}
+      - {value: 2.6339468750000004}
+      - {value: 2.6339468750000004}
+      - {value: 2.6339468750000004}
+      - {value: 4.214315000000001}
+      - {value: 4.214315000000001}
+      - {value: 4.214315000000001}
+      - {value: 4.214315000000001}
+      - {value: 4.214315000000001}
+      - {value: 4.214315000000001}
+      - {value: 4.214315000000001}
+      - {value: 4.214315000000001}
+      - {value: 4.214315000000001}
+      - {value: 4.214315000000001}
+      - {value: 4.214315000000001}
+      - {value: 6.321472500000001}
+      - {value: 6.321472500000001}
+      - {value: 6.321472500000001}
+      - {value: 6.321472500000001}
+      - {value: 6.321472500000001}
+      - {value: 1.8813906250000003}
+      - {value: 1.8813906250000003}
+      - {value: 1.8813906250000003}
+      - {value: 1.8813906250000003}
+      - {value: 2.633946875}
+      - {value: 2.633946875}
+      - {value: 2.633946875}
+      - {value: 2.633946875}
+      - {value: 2.633946875}
+      - {value: 2.633946875}
+      - {value: 2.633946875}
+      - {value: 3.7627812500000006}
+      - {value: 3.7627812500000006}
+      - {value: 3.7627812500000006}
+      - {value: 3.7627812500000006}
+      - {value: 3.7627812500000006}
+      - {value: 3.7627812500000006}
+      - {value: 3.7627812500000006}
+      - {value: 3.7627812500000006}
+      - {value: 3.7627812500000006}
+      - {value: 3.7627812500000006}
+      - {value: 6.020450000000002}
+      - {value: 6.020450000000002}
+      - {value: 6.020450000000002}
+      - {value: 6.020450000000002}
+      - {value: 6.020450000000002}
+      - {value: 6.020450000000002}
+      - {value: 6.020450000000002}
+      - {value: 6.020450000000002}
+      - {value: 6.020450000000002}
+      - {value: 6.020450000000002}
+      - {value: 6.020450000000002}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 3.0102250000000006}
+      - {value: 3.0102250000000006}
+      - {value: 3.0102250000000006}
+      - {value: 3.0102250000000006}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 6.020450000000001}
+      - {value: 6.020450000000001}
+      - {value: 6.020450000000001}
+      - {value: 6.020450000000001}
+      - {value: 6.020450000000001}
+      - {value: 6.020450000000001}
+      - {value: 6.020450000000001}
+      - {value: 6.020450000000001}
+      - {value: 6.020450000000001}
+      - {value: 6.020450000000001}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 14.449080000000002}
+      - {value: 14.449080000000002}
+      - {value: 14.449080000000002}
+      - {value: 14.449080000000002}
+      - {value: 14.449080000000002}
+      - {value: 4.515337500000001}
+      - {value: 4.515337500000001}
+      - {value: 4.515337500000001}
+      - {value: 4.515337500000001}
+      - {value: 6.321472500000001}
+      - {value: 6.321472500000001}
+      - {value: 6.321472500000001}
+      - {value: 6.321472500000001}
+      - {value: 6.321472500000001}
+      - {value: 6.321472500000001}
+      - {value: 6.321472500000001}
+      - {value: 9.030675000000002}
+      - {value: 9.030675000000002}
+      - {value: 9.030675000000002}
+      - {value: 9.030675000000002}
+      - {value: 9.030675000000002}
+      - {value: 9.030675000000002}
+      - {value: 9.030675000000002}
+      - {value: 9.030675000000002}
+      - {value: 9.030675000000002}
+      - {value: 9.030675000000002}
+      - {value: 14.449080000000004}
+      - {value: 14.449080000000004}
+      - {value: 14.449080000000004}
+      - {value: 14.449080000000004}
+      - {value: 14.449080000000004}
+      - {value: 14.449080000000004}
+      - {value: 14.449080000000004}
+      - {value: 14.449080000000004}
+      - {value: 14.449080000000004}
+      - {value: 14.449080000000004}
+      - {value: 14.449080000000004}
+      - {value: 21.673620000000007}
+      - {value: 21.673620000000007}
+      - {value: 21.673620000000007}
+      - {value: 21.673620000000007}
+      - {value: 21.673620000000007}
+      - {value: 6.020450000000001}
+      - {value: 6.020450000000001}
+      - {value: 6.020450000000001}
+      - {value: 6.020450000000001}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 12.040900000000002}
+      - {value: 12.040900000000002}
+      - {value: 12.040900000000002}
+      - {value: 12.040900000000002}
+      - {value: 12.040900000000002}
+      - {value: 12.040900000000002}
+      - {value: 12.040900000000002}
+      - {value: 12.040900000000002}
+      - {value: 12.040900000000002}
+      - {value: 12.040900000000002}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 28.898160000000004}
+      - {value: 28.898160000000004}
+      - {value: 28.898160000000004}
+      - {value: 28.898160000000004}
+      - {value: 15.276891875000002}
+      - {value: 15.276891875000002}
+      - {value: 15.276891875000002}
+      - {value: 15.276891875000002}
+      - {value: 15.276891875000002}
+      - {value: 15.276891875000002}
+      - {value: 15.276891875000002}
+      - {value: 21.824131250000004}
+      - {value: 21.824131250000004}
+      - {value: 21.824131250000004}
+      - {value: 21.824131250000004}
+      - {value: 21.824131250000004}
+      - {value: 21.824131250000004}
+      - {value: 21.824131250000004}
+      - {value: 21.824131250000004}
+      - {value: 21.824131250000004}
+      - {value: 21.824131250000004}
+      - {value: 34.91861000000001}
+      - {value: 34.91861000000001}
+      - {value: 34.91861000000001}
+      - {value: 34.91861000000001}
+      - {value: 34.91861000000001}
+      - {value: 34.91861000000001}
+      - {value: 34.91861000000001}
+      - {value: 34.91861000000001}
+      - {value: 34.91861000000001}
+      - {value: 34.91861000000001}
+      - {value: 34.91861000000001}
+      - {value: 52.37791500000001}
+      - {value: 52.37791500000001}
+      - {value: 52.37791500000001}
+      - {value: 52.37791500000001}
+      - {value: 52.37791500000001}

--- a/data/COMPASS_H_PLUS_2026.yaml
+++ b/data/COMPASS_H_PLUS_2026.yaml
@@ -1,0 +1,2472 @@
+dependent_variables:
+  - header: {title: COMPASS $H^+$ Multiplicities}
+    qualifiers:
+      - {name: process, value: SIDIS}
+      - {name: observable, value: dsigma/dxdydz}
+      - {name: target_isoscalarity, value: 0.5}
+      - {name: prefactor, value: 1}
+      - {name: Vs, value: 17.35}
+      - {name: Q, low: 0.9, high: 6.0, integrate: true}
+      - {name: x, low: 0.004, high: 0.4, integrate: true}
+      - {name: z, low: 0.2, high: 0.85, integrate: true}
+      - {name: PS_reduction, W: 5, ymin: 0.1, ymax: 0.7}
+      - {name: hadron, value: H}
+      - {name: charge, value: 1}
+    values:
+      - errors:
+          - {label: unc, value: 0.07434}
+          - {label: add, value: 0.037}
+        value: 2.5883
+      - errors:
+          - {label: unc, value: 0.0523}
+          - {label: add, value: 0.03684}
+        value: 1.8046
+      - errors:
+          - {label: unc, value: 0.03987}
+          - {label: add, value: 0.03663}
+        value: 1.3562
+      - errors:
+          - {label: unc, value: 0.02955}
+          - {label: add, value: 0.03647}
+        value: 0.9806
+      - errors:
+          - {label: unc, value: 0.02266}
+          - {label: add, value: 0.03672}
+        value: 0.7255
+      - errors:
+          - {label: unc, value: 0.01842}
+          - {label: add, value: 0.03743}
+        value: 0.5557
+      - errors:
+          - {label: unc, value: 0.0163}
+          - {label: add, value: 0.03897}
+        value: 0.4208
+      - errors:
+          - {label: unc, value: 0.01698}
+          - {label: add, value: 0.04001}
+        value: 0.3519
+      - errors:
+          - {label: unc, value: 0.02175}
+          - {label: add, value: 0.04571}
+        value: 0.2923
+      - errors:
+          - {label: unc, value: 0.03285}
+          - {label: add, value: 0.03955}
+        value: 0.2023
+      - errors:
+          - {label: unc, value: 0.07064}
+          - {label: add, value: 0.03634}
+        value: 2.5535
+      - errors:
+          - {label: unc, value: 0.05037}
+          - {label: add, value: 0.03614}
+        value: 1.8154
+      - errors:
+          - {label: unc, value: 0.03642}
+          - {label: add, value: 0.03598}
+        value: 1.3028
+      - errors:
+          - {label: unc, value: 0.02785}
+          - {label: add, value: 0.03596}
+        value: 0.9566
+      - errors:
+          - {label: unc, value: 0.02406}
+          - {label: add, value: 0.03615}
+        value: 0.7193
+      - errors:
+          - {label: unc, value: 0.03596}
+          - {label: add, value: 0.03768}
+        value: 0.7623
+      - errors:
+          - {label: unc, value: 0.02652}
+          - {label: add, value: 0.03759}
+        value: 0.6257
+      - errors:
+          - {label: unc, value: 0.02179}
+          - {label: add, value: 0.03818}
+        value: 0.4672
+      - errors:
+          - {label: unc, value: 0.01832}
+          - {label: add, value: 0.04127}
+        value: 0.3489
+      - errors:
+          - {label: unc, value: 0.01635}
+          - {label: add, value: 0.04585}
+        value: 0.2722
+      - errors:
+          - {label: unc, value: 0.01437}
+          - {label: add, value: 0.04251}
+        value: 0.2277
+      - errors:
+          - {label: unc, value: 0.01453}
+          - {label: add, value: 0.05127}
+        value: 0.2013
+      - errors:
+          - {label: unc, value: 0.00949}
+          - {label: add, value: 0.06412}
+        value: 0.131
+      - errors:
+          - {label: unc, value: 0.04112}
+          - {label: add, value: 0.03756}
+        value: 1.3824
+      - errors:
+          - {label: unc, value: 0.0306}
+          - {label: add, value: 0.03739}
+        value: 1.042
+      - errors:
+          - {label: unc, value: 0.02309}
+          - {label: add, value: 0.03746}
+        value: 0.7773
+      - errors:
+          - {label: unc, value: 0.01783}
+          - {label: add, value: 0.03756}
+        value: 0.5879
+      - errors:
+          - {label: unc, value: 0.01425}
+          - {label: add, value: 0.03825}
+        value: 0.4539
+      - errors:
+          - {label: unc, value: 0.01157}
+          - {label: add, value: 0.04043}
+        value: 0.3423
+      - errors:
+          - {label: unc, value: 0.00963}
+          - {label: add, value: 0.0396}
+        value: 0.2828
+      - errors:
+          - {label: unc, value: 0.00782}
+          - {label: add, value: 0.0405}
+        value: 0.2173
+      - errors:
+          - {label: unc, value: 0.00731}
+          - {label: add, value: 0.04612}
+        value: 0.1804
+      - errors:
+          - {label: unc, value: 0.00598}
+          - {label: add, value: 0.06023}
+        value: 0.1222
+      - errors:
+          - {label: unc, value: 0.07336}
+          - {label: add, value: 0.03715}
+        value: 2.5946
+      - errors:
+          - {label: unc, value: 0.05272}
+          - {label: add, value: 0.03705}
+        value: 1.8744
+      - errors:
+          - {label: unc, value: 0.03823}
+          - {label: add, value: 0.0369}
+        value: 1.357
+      - errors:
+          - {label: unc, value: 0.02846}
+          - {label: add, value: 0.03675}
+        value: 1.0078
+      - errors:
+          - {label: unc, value: 0.02148}
+          - {label: add, value: 0.03678}
+        value: 0.7526
+      - errors:
+          - {label: unc, value: 0.01626}
+          - {label: add, value: 0.03681}
+        value: 0.5629
+      - errors:
+          - {label: unc, value: 0.01293}
+          - {label: add, value: 0.03742}
+        value: 0.4318
+      - errors:
+          - {label: unc, value: 0.01082}
+          - {label: add, value: 0.03935}
+        value: 0.3334
+      - errors:
+          - {label: unc, value: 0.00911}
+          - {label: add, value: 0.03974}
+        value: 0.2637
+      - errors:
+          - {label: unc, value: 0.00833}
+          - {label: add, value: 0.041}
+        value: 0.2166
+      - errors:
+          - {label: unc, value: 0.0081}
+          - {label: add, value: 0.04602}
+        value: 0.1669
+      - errors:
+          - {label: unc, value: 0.07118}
+          - {label: add, value: 0.03655}
+        value: 2.5586
+      - errors:
+          - {label: unc, value: 0.05056}
+          - {label: add, value: 0.03645}
+        value: 1.8087
+      - errors:
+          - {label: unc, value: 0.03631}
+          - {label: add, value: 0.03628}
+        value: 1.2899
+      - errors:
+          - {label: unc, value: 0.02772}
+          - {label: add, value: 0.03618}
+        value: 0.9597
+      - errors:
+          - {label: unc, value: 0.02269}
+          - {label: add, value: 0.03627}
+        value: 0.7147
+      - errors:
+          - {label: unc, value: 0.0169}
+          - {label: add, value: 0.03997}
+        value: 0.3643
+      - errors:
+          - {label: unc, value: 0.01346}
+          - {label: add, value: 0.04117}
+        value: 0.309
+      - errors:
+          - {label: unc, value: 0.01144}
+          - {label: add, value: 0.04271}
+        value: 0.2491
+      - errors:
+          - {label: unc, value: 0.00985}
+          - {label: add, value: 0.0444}
+        value: 0.2018
+      - errors:
+          - {label: unc, value: 0.00724}
+          - {label: add, value: 0.05843}
+        value: 0.1328
+      - errors:
+          - {label: unc, value: 0.03088}
+          - {label: add, value: 0.03761}
+        value: 0.8189
+      - errors:
+          - {label: unc, value: 0.02007}
+          - {label: add, value: 0.0378}
+        value: 0.6159
+      - errors:
+          - {label: unc, value: 0.01547}
+          - {label: add, value: 0.03854}
+        value: 0.4753
+      - errors:
+          - {label: unc, value: 0.01277}
+          - {label: add, value: 0.03953}
+        value: 0.3764
+      - errors:
+          - {label: unc, value: 0.01055}
+          - {label: add, value: 0.04009}
+        value: 0.2973
+      - errors:
+          - {label: unc, value: 0.00887}
+          - {label: add, value: 0.04072}
+        value: 0.2377
+      - errors:
+          - {label: unc, value: 0.00764}
+          - {label: add, value: 0.04421}
+        value: 0.1864
+      - errors:
+          - {label: unc, value: 0.00605}
+          - {label: add, value: 0.05796}
+        value: 0.1256
+      - errors:
+          - {label: unc, value: 0.04239}
+          - {label: add, value: 0.03763}
+        value: 1.3819
+      - errors:
+          - {label: unc, value: 0.03148}
+          - {label: add, value: 0.03741}
+        value: 1.0564
+      - errors:
+          - {label: unc, value: 0.02367}
+          - {label: add, value: 0.03728}
+        value: 0.7939
+      - errors:
+          - {label: unc, value: 0.01824}
+          - {label: add, value: 0.03722}
+        value: 0.6019
+      - errors:
+          - {label: unc, value: 0.01467}
+          - {label: add, value: 0.03748}
+        value: 0.4696
+      - errors:
+          - {label: unc, value: 0.01148}
+          - {label: add, value: 0.03804}
+        value: 0.3533
+      - errors:
+          - {label: unc, value: 0.00926}
+          - {label: add, value: 0.03808}
+        value: 0.2752
+      - errors:
+          - {label: unc, value: 0.00778}
+          - {label: add, value: 0.03875}
+        value: 0.2209
+      - errors:
+          - {label: unc, value: 0.00687}
+          - {label: add, value: 0.04251}
+        value: 0.175
+      - errors:
+          - {label: unc, value: 0.00542}
+          - {label: add, value: 0.05251}
+        value: 0.1234
+      - errors:
+          - {label: unc, value: 0.07575}
+          - {label: add, value: 0.03722}
+        value: 2.635
+      - errors:
+          - {label: unc, value: 0.054}
+          - {label: add, value: 0.03726}
+        value: 1.8872
+      - errors:
+          - {label: unc, value: 0.03905}
+          - {label: add, value: 0.03709}
+        value: 1.359
+      - errors:
+          - {label: unc, value: 0.02934}
+          - {label: add, value: 0.03695}
+        value: 1.0111
+      - errors:
+          - {label: unc, value: 0.02222}
+          - {label: add, value: 0.03683}
+        value: 0.756
+      - errors:
+          - {label: unc, value: 0.01683}
+          - {label: add, value: 0.03676}
+        value: 0.5615
+      - errors:
+          - {label: unc, value: 0.01324}
+          - {label: add, value: 0.0367}
+        value: 0.4251
+      - errors:
+          - {label: unc, value: 0.01122}
+          - {label: add, value: 0.03724}
+        value: 0.3373
+      - errors:
+          - {label: unc, value: 0.00937}
+          - {label: add, value: 0.03744}
+        value: 0.2564
+      - errors:
+          - {label: unc, value: 0.00826}
+          - {label: add, value: 0.0379}
+        value: 0.1921
+      - errors:
+          - {label: unc, value: 0.00895}
+          - {label: add, value: 0.03948}
+        value: 0.1702
+      - errors:
+          - {label: unc, value: 0.07467}
+          - {label: add, value: 0.03679}
+        value: 2.6074
+      - errors:
+          - {label: unc, value: 0.05389}
+          - {label: add, value: 0.03666}
+        value: 1.8527
+      - errors:
+          - {label: unc, value: 0.03956}
+          - {label: add, value: 0.03648}
+        value: 1.3332
+      - errors:
+          - {label: unc, value: 0.0313}
+          - {label: add, value: 0.03648}
+        value: 0.9979
+      - errors:
+          - {label: unc, value: 0.02763}
+          - {label: add, value: 0.03641}
+        value: 0.7515
+      - errors:
+          - {label: unc, value: 0.01641}
+          - {label: add, value: 0.03792}
+        value: 0.3565
+      - errors:
+          - {label: unc, value: 0.0124}
+          - {label: add, value: 0.03912}
+        value: 0.3047
+      - errors:
+          - {label: unc, value: 0.0097}
+          - {label: add, value: 0.03952}
+        value: 0.249
+      - errors:
+          - {label: unc, value: 0.00784}
+          - {label: add, value: 0.04334}
+        value: 0.1883
+      - errors:
+          - {label: unc, value: 0.00619}
+          - {label: add, value: 0.05361}
+        value: 0.1373
+      - errors:
+          - {label: unc, value: 0.03619}
+          - {label: add, value: 0.03782}
+        value: 0.8291
+      - errors:
+          - {label: unc, value: 0.02232}
+          - {label: add, value: 0.03768}
+        value: 0.6263
+      - errors:
+          - {label: unc, value: 0.0167}
+          - {label: add, value: 0.03769}
+        value: 0.4882
+      - errors:
+          - {label: unc, value: 0.01313}
+          - {label: add, value: 0.03812}
+        value: 0.3694
+      - errors:
+          - {label: unc, value: 0.01103}
+          - {label: add, value: 0.03816}
+        value: 0.2977
+      - errors:
+          - {label: unc, value: 0.00899}
+          - {label: add, value: 0.03889}
+        value: 0.2263
+      - errors:
+          - {label: unc, value: 0.00752}
+          - {label: add, value: 0.04076}
+        value: 0.1747
+      - errors:
+          - {label: unc, value: 0.00563}
+          - {label: add, value: 0.04769}
+        value: 0.1275
+      - errors:
+          - {label: unc, value: 0.04418}
+          - {label: add, value: 0.03781}
+        value: 1.3944
+      - errors:
+          - {label: unc, value: 0.03252}
+          - {label: add, value: 0.03776}
+        value: 1.0572
+      - errors:
+          - {label: unc, value: 0.02457}
+          - {label: add, value: 0.03764}
+        value: 0.7949
+      - errors:
+          - {label: unc, value: 0.01912}
+          - {label: add, value: 0.0375}
+        value: 0.6037
+      - errors:
+          - {label: unc, value: 0.01466}
+          - {label: add, value: 0.03743}
+        value: 0.4488
+      - errors:
+          - {label: unc, value: 0.01175}
+          - {label: add, value: 0.03765}
+        value: 0.3442
+      - errors:
+          - {label: unc, value: 0.00962}
+          - {label: add, value: 0.03781}
+        value: 0.2708
+      - errors:
+          - {label: unc, value: 0.00789}
+          - {label: add, value: 0.03791}
+        value: 0.2089
+      - errors:
+          - {label: unc, value: 0.00665}
+          - {label: add, value: 0.03965}
+        value: 0.1614
+      - errors:
+          - {label: unc, value: 0.005}
+          - {label: add, value: 0.04698}
+        value: 0.1175
+      - errors:
+          - {label: unc, value: 0.07937}
+          - {label: add, value: 0.03763}
+        value: 2.6851
+      - errors:
+          - {label: unc, value: 0.05556}
+          - {label: add, value: 0.03764}
+        value: 1.898
+      - errors:
+          - {label: unc, value: 0.04047}
+          - {label: add, value: 0.03748}
+        value: 1.3703
+      - errors:
+          - {label: unc, value: 0.03091}
+          - {label: add, value: 0.03739}
+        value: 1.0314
+      - errors:
+          - {label: unc, value: 0.02327}
+          - {label: add, value: 0.03719}
+        value: 0.7615
+      - errors:
+          - {label: unc, value: 0.01773}
+          - {label: add, value: 0.03702}
+        value: 0.5662
+      - errors:
+          - {label: unc, value: 0.01421}
+          - {label: add, value: 0.03704}
+        value: 0.4277
+      - errors:
+          - {label: unc, value: 0.0121}
+          - {label: add, value: 0.03702}
+        value: 0.3393
+      - errors:
+          - {label: unc, value: 0.00993}
+          - {label: add, value: 0.0373}
+        value: 0.2445
+      - errors:
+          - {label: unc, value: 0.00909}
+          - {label: add, value: 0.03711}
+        value: 0.1897
+      - errors:
+          - {label: unc, value: 0.00947}
+          - {label: add, value: 0.03805}
+        value: 0.1535
+      - errors:
+          - {label: unc, value: 0.07688}
+          - {label: add, value: 0.03707}
+        value: 2.581
+      - errors:
+          - {label: unc, value: 0.0568}
+          - {label: add, value: 0.03698}
+        value: 1.8475
+      - errors:
+          - {label: unc, value: 0.04323}
+          - {label: add, value: 0.03685}
+        value: 1.3569
+      - errors:
+          - {label: unc, value: 0.0344}
+          - {label: add, value: 0.03673}
+        value: 0.9889
+      - errors:
+          - {label: unc, value: 0.03081}
+          - {label: add, value: 0.03677}
+        value: 0.718
+      - errors:
+          - {label: unc, value: 0.01686}
+          - {label: add, value: 0.03839}
+        value: 0.3813
+      - errors:
+          - {label: unc, value: 0.01162}
+          - {label: add, value: 0.0382}
+        value: 0.2974
+      - errors:
+          - {label: unc, value: 0.00936}
+          - {label: add, value: 0.03933}
+        value: 0.2461
+      - errors:
+          - {label: unc, value: 0.00726}
+          - {label: add, value: 0.04002}
+        value: 0.1899
+      - errors:
+          - {label: unc, value: 0.00541}
+          - {label: add, value: 0.04716}
+        value: 0.1357
+      - errors:
+          - {label: unc, value: 0.03209}
+          - {label: add, value: 0.03792}
+        value: 0.7974
+      - errors:
+          - {label: unc, value: 0.02121}
+          - {label: add, value: 0.03779}
+        value: 0.6267
+      - errors:
+          - {label: unc, value: 0.0159}
+          - {label: add, value: 0.03777}
+        value: 0.4808
+      - errors:
+          - {label: unc, value: 0.01241}
+          - {label: add, value: 0.03773}
+        value: 0.3668
+      - errors:
+          - {label: unc, value: 0.00998}
+          - {label: add, value: 0.0377}
+        value: 0.2822
+      - errors:
+          - {label: unc, value: 0.00823}
+          - {label: add, value: 0.03792}
+        value: 0.2215
+      - errors:
+          - {label: unc, value: 0.00709}
+          - {label: add, value: 0.03932}
+        value: 0.177
+      - errors:
+          - {label: unc, value: 0.00479}
+          - {label: add, value: 0.04486}
+        value: 0.1177
+      - errors:
+          - {label: unc, value: 0.04525}
+          - {label: add, value: 0.03808}
+        value: 1.4579
+      - errors:
+          - {label: unc, value: 0.0326}
+          - {label: add, value: 0.03803}
+        value: 1.077
+      - errors:
+          - {label: unc, value: 0.02419}
+          - {label: add, value: 0.03806}
+        value: 0.7946
+      - errors:
+          - {label: unc, value: 0.01885}
+          - {label: add, value: 0.0379}
+        value: 0.61
+      - errors:
+          - {label: unc, value: 0.01455}
+          - {label: add, value: 0.0378}
+        value: 0.4592
+      - errors:
+          - {label: unc, value: 0.01148}
+          - {label: add, value: 0.03779}
+        value: 0.3535
+      - errors:
+          - {label: unc, value: 0.0088}
+          - {label: add, value: 0.03767}
+        value: 0.2612
+      - errors:
+          - {label: unc, value: 0.00698}
+          - {label: add, value: 0.03771}
+        value: 0.1973
+      - errors:
+          - {label: unc, value: 0.00594}
+          - {label: add, value: 0.03843}
+        value: 0.1582
+      - errors:
+          - {label: unc, value: 0.00402}
+          - {label: add, value: 0.04263}
+        value: 0.1051
+      - errors:
+          - {label: unc, value: 0.07955}
+          - {label: add, value: 0.03798}
+        value: 2.6879
+      - errors:
+          - {label: unc, value: 0.05663}
+          - {label: add, value: 0.03798}
+        value: 1.9314
+      - errors:
+          - {label: unc, value: 0.04153}
+          - {label: add, value: 0.03787}
+        value: 1.407
+      - errors:
+          - {label: unc, value: 0.03065}
+          - {label: add, value: 0.03772}
+        value: 1.0264
+      - errors:
+          - {label: unc, value: 0.0239}
+          - {label: add, value: 0.03756}
+        value: 0.7902
+      - errors:
+          - {label: unc, value: 0.01754}
+          - {label: add, value: 0.03744}
+        value: 0.5662
+      - errors:
+          - {label: unc, value: 0.014}
+          - {label: add, value: 0.0373}
+        value: 0.4333
+      - errors:
+          - {label: unc, value: 0.01121}
+          - {label: add, value: 0.03726}
+        value: 0.3242
+      - errors:
+          - {label: unc, value: 0.00957}
+          - {label: add, value: 0.03744}
+        value: 0.25
+      - errors:
+          - {label: unc, value: 0.00857}
+          - {label: add, value: 0.03753}
+        value: 0.1897
+      - errors:
+          - {label: unc, value: 0.00869}
+          - {label: add, value: 0.03787}
+        value: 0.1542
+      - errors:
+          - {label: unc, value: 0.07918}
+          - {label: add, value: 0.03722}
+        value: 2.6265
+      - errors:
+          - {label: unc, value: 0.0592}
+          - {label: add, value: 0.03707}
+        value: 1.9078
+      - errors:
+          - {label: unc, value: 0.04414}
+          - {label: add, value: 0.03694}
+        value: 1.3665
+      - errors:
+          - {label: unc, value: 0.03439}
+          - {label: add, value: 0.03671}
+        value: 0.9719
+      - errors:
+          - {label: unc, value: 0.03284}
+          - {label: add, value: 0.03677}
+        value: 0.768
+      - errors:
+          - {label: unc, value: 0.01557}
+          - {label: add, value: 0.03829}
+        value: 0.3656
+      - errors:
+          - {label: unc, value: 0.01088}
+          - {label: add, value: 0.0381}
+        value: 0.2856
+      - errors:
+          - {label: unc, value: 0.00862}
+          - {label: add, value: 0.03842}
+        value: 0.2332
+      - errors:
+          - {label: unc, value: 0.0069}
+          - {label: add, value: 0.03926}
+        value: 0.1834
+      - errors:
+          - {label: unc, value: 0.00463}
+          - {label: add, value: 0.0434}
+        value: 0.1235
+      - errors:
+          - {label: unc, value: 0.03102}
+          - {label: add, value: 0.03857}
+        value: 0.7924
+      - errors:
+          - {label: unc, value: 0.02001}
+          - {label: add, value: 0.03816}
+        value: 0.5996
+      - errors:
+          - {label: unc, value: 0.01535}
+          - {label: add, value: 0.03801}
+        value: 0.4736
+      - errors:
+          - {label: unc, value: 0.01194}
+          - {label: add, value: 0.03788}
+        value: 0.3611
+      - errors:
+          - {label: unc, value: 0.00953}
+          - {label: add, value: 0.03784}
+        value: 0.2791
+      - errors:
+          - {label: unc, value: 0.00772}
+          - {label: add, value: 0.03774}
+        value: 0.2162
+      - errors:
+          - {label: unc, value: 0.00607}
+          - {label: add, value: 0.03831}
+        value: 0.1587
+      - errors:
+          - {label: unc, value: 0.00428}
+          - {label: add, value: 0.04104}
+        value: 0.115
+      - errors:
+          - {label: unc, value: 0.04408}
+          - {label: add, value: 0.03871}
+        value: 1.4096
+      - errors:
+          - {label: unc, value: 0.03191}
+          - {label: add, value: 0.03849}
+        value: 1.0475
+      - errors:
+          - {label: unc, value: 0.02402}
+          - {label: add, value: 0.03827}
+        value: 0.7901
+      - errors:
+          - {label: unc, value: 0.0185}
+          - {label: add, value: 0.0381}
+        value: 0.6006
+      - errors:
+          - {label: unc, value: 0.01428}
+          - {label: add, value: 0.03803}
+        value: 0.4544
+      - errors:
+          - {label: unc, value: 0.01123}
+          - {label: add, value: 0.03782}
+        value: 0.349
+      - errors:
+          - {label: unc, value: 0.00859}
+          - {label: add, value: 0.03767}
+        value: 0.2591
+      - errors:
+          - {label: unc, value: 0.00711}
+          - {label: add, value: 0.03758}
+        value: 0.2086
+      - errors:
+          - {label: unc, value: 0.0055}
+          - {label: add, value: 0.0381}
+        value: 0.1512
+      - errors:
+          - {label: unc, value: 0.0035}
+          - {label: add, value: 0.03992}
+        value: 0.0982
+      - errors:
+          - {label: unc, value: 0.08371}
+          - {label: add, value: 0.03857}
+        value: 2.7479
+      - errors:
+          - {label: unc, value: 0.05799}
+          - {label: add, value: 0.03851}
+        value: 1.9403
+      - errors:
+          - {label: unc, value: 0.04345}
+          - {label: add, value: 0.03838}
+        value: 1.4446
+      - errors:
+          - {label: unc, value: 0.03203}
+          - {label: add, value: 0.0382}
+        value: 1.0512
+      - errors:
+          - {label: unc, value: 0.02333}
+          - {label: add, value: 0.03807}
+        value: 0.7522
+      - errors:
+          - {label: unc, value: 0.01853}
+          - {label: add, value: 0.03793}
+        value: 0.5842
+      - errors:
+          - {label: unc, value: 0.01461}
+          - {label: add, value: 0.03771}
+        value: 0.4434
+      - errors:
+          - {label: unc, value: 0.01163}
+          - {label: add, value: 0.03762}
+        value: 0.3317
+      - errors:
+          - {label: unc, value: 0.00975}
+          - {label: add, value: 0.0374}
+        value: 0.2524
+      - errors:
+          - {label: unc, value: 0.00876}
+          - {label: add, value: 0.03748}
+        value: 0.1921
+      - errors:
+          - {label: unc, value: 0.00831}
+          - {label: add, value: 0.0376}
+        value: 0.1468
+      - errors:
+          - {label: unc, value: 0.08743}
+          - {label: add, value: 0.03796}
+        value: 2.6953
+      - errors:
+          - {label: unc, value: 0.06663}
+          - {label: add, value: 0.03781}
+        value: 1.9636
+      - errors:
+          - {label: unc, value: 0.05174}
+          - {label: add, value: 0.03761}
+        value: 1.4356
+      - errors:
+          - {label: unc, value: 0.04081}
+          - {label: add, value: 0.03744}
+        value: 1.0042
+      - errors:
+          - {label: unc, value: 0.04093}
+          - {label: add, value: 0.03739}
+        value: 0.7853
+      - errors:
+          - {label: unc, value: 0.01809}
+          - {label: add, value: 0.03858}
+        value: 0.3442
+      - errors:
+          - {label: unc, value: 0.01272}
+          - {label: add, value: 0.03818}
+        value: 0.2787
+      - errors:
+          - {label: unc, value: 0.00972}
+          - {label: add, value: 0.03792}
+        value: 0.2215
+      - errors:
+          - {label: unc, value: 0.00722}
+          - {label: add, value: 0.03849}
+        value: 0.1621
+      - errors:
+          - {label: unc, value: 0.0048}
+          - {label: add, value: 0.04077}
+        value: 0.1197
+      - errors:
+          - {label: unc, value: 0.0368}
+          - {label: add, value: 0.03878}
+        value: 0.7963
+      - errors:
+          - {label: unc, value: 0.02208}
+          - {label: add, value: 0.03857}
+        value: 0.5932
+      - errors:
+          - {label: unc, value: 0.01663}
+          - {label: add, value: 0.03854}
+        value: 0.465
+      - errors:
+          - {label: unc, value: 0.01309}
+          - {label: add, value: 0.03823}
+        value: 0.3557
+      - errors:
+          - {label: unc, value: 0.01019}
+          - {label: add, value: 0.0382}
+        value: 0.2618
+      - errors:
+          - {label: unc, value: 0.00828}
+          - {label: add, value: 0.03796}
+        value: 0.2002
+      - errors:
+          - {label: unc, value: 0.00688}
+          - {label: add, value: 0.0381}
+        value: 0.1533
+      - errors:
+          - {label: unc, value: 0.00417}
+          - {label: add, value: 0.03964}
+        value: 0.1009
+      - errors:
+          - {label: unc, value: 0.04939}
+          - {label: add, value: 0.0391}
+        value: 1.4362
+      - errors:
+          - {label: unc, value: 0.0351}
+          - {label: add, value: 0.03875}
+        value: 1.0817
+      - errors:
+          - {label: unc, value: 0.02656}
+          - {label: add, value: 0.03861}
+        value: 0.8184
+      - errors:
+          - {label: unc, value: 0.02012}
+          - {label: add, value: 0.03843}
+        value: 0.6016
+      - errors:
+          - {label: unc, value: 0.01551}
+          - {label: add, value: 0.03827}
+        value: 0.4473
+      - errors:
+          - {label: unc, value: 0.01239}
+          - {label: add, value: 0.03821}
+        value: 0.3413
+      - errors:
+          - {label: unc, value: 0.00974}
+          - {label: add, value: 0.03801}
+        value: 0.2547
+      - errors:
+          - {label: unc, value: 0.00809}
+          - {label: add, value: 0.03773}
+        value: 0.1993
+      - errors:
+          - {label: unc, value: 0.00676}
+          - {label: add, value: 0.03817}
+        value: 0.1551
+      - errors:
+          - {label: unc, value: 0.00389}
+          - {label: add, value: 0.0385}
+        value: 0.0935
+      - errors:
+          - {label: unc, value: 0.09418}
+          - {label: add, value: 0.03834}
+        value: 2.7688
+      - errors:
+          - {label: unc, value: 0.06322}
+          - {label: add, value: 0.03868}
+        value: 1.9692
+      - errors:
+          - {label: unc, value: 0.04842}
+          - {label: add, value: 0.03856}
+        value: 1.475
+      - errors:
+          - {label: unc, value: 0.03623}
+          - {label: add, value: 0.03837}
+        value: 1.0612
+      - errors:
+          - {label: unc, value: 0.02864}
+          - {label: add, value: 0.0382}
+        value: 0.802
+      - errors:
+          - {label: unc, value: 0.02237}
+          - {label: add, value: 0.03804}
+        value: 0.5909
+      - errors:
+          - {label: unc, value: 0.01848}
+          - {label: add, value: 0.03798}
+        value: 0.4466
+      - errors:
+          - {label: unc, value: 0.01591}
+          - {label: add, value: 0.03778}
+        value: 0.343
+      - errors:
+          - {label: unc, value: 0.0135}
+          - {label: add, value: 0.03797}
+        value: 0.2486
+      - errors:
+          - {label: unc, value: 0.0128}
+          - {label: add, value: 0.03764}
+        value: 0.1913
+      - errors:
+          - {label: unc, value: 0.01351}
+          - {label: add, value: 0.03794}
+        value: 0.1518
+      - errors:
+          - {label: unc, value: 0.11235}
+          - {label: add, value: 0.03842}
+        value: 2.6945
+      - errors:
+          - {label: unc, value: 0.09283}
+          - {label: add, value: 0.0383}
+        value: 2.0051
+      - errors:
+          - {label: unc, value: 0.07377}
+          - {label: add, value: 0.03815}
+        value: 1.4345
+      - errors:
+          - {label: unc, value: 0.06793}
+          - {label: add, value: 0.03801}
+        value: 1.0838
+      - errors:
+          - {label: unc, value: 0.06281}
+          - {label: add, value: 0.03788}
+        value: 0.7286
+      - errors:
+          - {label: unc, value: 0.02484}
+          - {label: add, value: 0.0383}
+        value: 0.3593
+      - errors:
+          - {label: unc, value: 0.0151}
+          - {label: add, value: 0.0382}
+        value: 0.2618
+      - errors:
+          - {label: unc, value: 0.01151}
+          - {label: add, value: 0.03823}
+        value: 0.2051
+      - errors:
+          - {label: unc, value: 0.00918}
+          - {label: add, value: 0.03807}
+        value: 0.1639
+      - errors:
+          - {label: unc, value: 0.00546}
+          - {label: add, value: 0.03926}
+        value: 0.1141
+      - errors:
+          - {label: unc, value: 0.0498}
+          - {label: add, value: 0.03917}
+        value: 0.8373
+      - errors:
+          - {label: unc, value: 0.02666}
+          - {label: add, value: 0.03908}
+        value: 0.5978
+      - errors:
+          - {label: unc, value: 0.01889}
+          - {label: add, value: 0.03863}
+        value: 0.4452
+      - errors:
+          - {label: unc, value: 0.01545}
+          - {label: add, value: 0.03861}
+        value: 0.3522
+      - errors:
+          - {label: unc, value: 0.01192}
+          - {label: add, value: 0.03831}
+        value: 0.2506
+      - errors:
+          - {label: unc, value: 0.01035}
+          - {label: add, value: 0.0383}
+        value: 0.2005
+      - errors:
+          - {label: unc, value: 0.00787}
+          - {label: add, value: 0.03837}
+        value: 0.1376
+      - errors:
+          - {label: unc, value: 0.00493}
+          - {label: add, value: 0.03947}
+        value: 0.0973
+      - errors:
+          - {label: unc, value: 0.05629}
+          - {label: add, value: 0.03948}
+        value: 1.3738
+      - errors:
+          - {label: unc, value: 0.03883}
+          - {label: add, value: 0.03916}
+        value: 1.0602
+      - errors:
+          - {label: unc, value: 0.02862}
+          - {label: add, value: 0.03892}
+        value: 0.7811
+      - errors:
+          - {label: unc, value: 0.02315}
+          - {label: add, value: 0.03874}
+        value: 0.6009
+      - errors:
+          - {label: unc, value: 0.01853}
+          - {label: add, value: 0.03858}
+        value: 0.4562
+      - errors:
+          - {label: unc, value: 0.01503}
+          - {label: add, value: 0.03845}
+        value: 0.3475
+      - errors:
+          - {label: unc, value: 0.01279}
+          - {label: add, value: 0.03826}
+        value: 0.2781
+      - errors:
+          - {label: unc, value: 0.01}
+          - {label: add, value: 0.03827}
+        value: 0.1944
+      - errors:
+          - {label: unc, value: 0.00883}
+          - {label: add, value: 0.03822}
+        value: 0.157
+      - errors:
+          - {label: unc, value: 0.00479}
+          - {label: add, value: 0.03822}
+        value: 0.0921
+      - errors:
+          - {label: unc, value: 0.11439}
+          - {label: add, value: 0.03879}
+        value: 2.8174
+      - errors:
+          - {label: unc, value: 0.07432}
+          - {label: add, value: 0.039}
+        value: 2.0347
+      - errors:
+          - {label: unc, value: 0.05545}
+          - {label: add, value: 0.03888}
+        value: 1.4465
+      - errors:
+          - {label: unc, value: 0.04456}
+          - {label: add, value: 0.03874}
+        value: 1.0883
+      - errors:
+          - {label: unc, value: 0.03599}
+          - {label: add, value: 0.03851}
+        value: 0.808
+      - errors:
+          - {label: unc, value: 0.0302}
+          - {label: add, value: 0.03841}
+        value: 0.6228
+      - errors:
+          - {label: unc, value: 0.02643}
+          - {label: add, value: 0.03828}
+        value: 0.4827
+      - errors:
+          - {label: unc, value: 0.02114}
+          - {label: add, value: 0.03811}
+        value: 0.317
+      - errors:
+          - {label: unc, value: 0.02183}
+          - {label: add, value: 0.03825}
+        value: 0.2886
+      - errors:
+          - {label: unc, value: 0.01776}
+          - {label: add, value: 0.03819}
+        value: 0.1676
+      - errors:
+          - {label: unc, value: 0.02314}
+          - {label: add, value: 0.03871}
+        value: 0.186
+      - errors:
+          - {label: unc, value: 0.04747}
+          - {label: add, value: 0.03947}
+        value: 0.754
+      - errors:
+          - {label: unc, value: 0.02792}
+          - {label: add, value: 0.03929}
+        value: 0.6047
+      - errors:
+          - {label: unc, value: 0.02162}
+          - {label: add, value: 0.03897}
+        value: 0.505
+      - errors:
+          - {label: unc, value: 0.01675}
+          - {label: add, value: 0.03876}
+        value: 0.3633
+      - errors:
+          - {label: unc, value: 0.01386}
+          - {label: add, value: 0.03879}
+        value: 0.2805
+      - errors:
+          - {label: unc, value: 0.01129}
+          - {label: add, value: 0.03852}
+        value: 0.2056
+      - errors:
+          - {label: unc, value: 0.00886}
+          - {label: add, value: 0.03849}
+        value: 0.1455
+      - errors:
+          - {label: unc, value: 0.0049}
+          - {label: add, value: 0.03831}
+        value: 0.0877
+      - errors:
+          - {label: unc, value: 0.059}
+          - {label: add, value: 0.04007}
+        value: 1.3857
+      - errors:
+          - {label: unc, value: 0.03756}
+          - {label: add, value: 0.03976}
+        value: 0.98
+      - errors:
+          - {label: unc, value: 0.02991}
+          - {label: add, value: 0.03949}
+        value: 0.7881
+      - errors:
+          - {label: unc, value: 0.02324}
+          - {label: add, value: 0.03933}
+        value: 0.5777
+      - errors:
+          - {label: unc, value: 0.01972}
+          - {label: add, value: 0.03923}
+        value: 0.4649
+      - errors:
+          - {label: unc, value: 0.0156}
+          - {label: add, value: 0.03916}
+        value: 0.3432
+      - errors:
+          - {label: unc, value: 0.01266}
+          - {label: add, value: 0.03902}
+        value: 0.2563
+      - errors:
+          - {label: unc, value: 0.01117}
+          - {label: add, value: 0.03867}
+        value: 0.2131
+      - errors:
+          - {label: unc, value: 0.0086}
+          - {label: add, value: 0.03889}
+        value: 0.144
+      - errors:
+          - {label: unc, value: 0.00508}
+          - {label: add, value: 0.039}
+        value: 0.0923
+      - errors:
+          - {label: unc, value: 0.12065}
+          - {label: add, value: 0.03903}
+        value: 2.8448
+      - errors:
+          - {label: unc, value: 0.07227}
+          - {label: add, value: 0.03919}
+        value: 1.9454
+      - errors:
+          - {label: unc, value: 0.05728}
+          - {label: add, value: 0.03907}
+        value: 1.4805
+      - errors:
+          - {label: unc, value: 0.0467}
+          - {label: add, value: 0.039}
+        value: 1.1363
+      - errors:
+          - {label: unc, value: 0.03769}
+          - {label: add, value: 0.03882}
+        value: 0.8512
+      - errors:
+          - {label: unc, value: 0.02814}
+          - {label: add, value: 0.03875}
+        value: 0.5677
+      - errors:
+          - {label: unc, value: 0.02391}
+          - {label: add, value: 0.03855}
+        value: 0.4316
+      - errors:
+          - {label: unc, value: 0.02178}
+          - {label: add, value: 0.03831}
+        value: 0.3446
+      - errors:
+          - {label: unc, value: 0.02079}
+          - {label: add, value: 0.03833}
+        value: 0.2776
+      - errors:
+          - {label: unc, value: 0.01796}
+          - {label: add, value: 0.03807}
+        value: 0.1807
+independent_variables:
+  - header: {name: z}
+    values:
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+  - header: {name: x}
+    values:
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+  - header: {name: y}
+    values:
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+  - header: {name: Q2}
+    values:
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}

--- a/data/COMPASS_KA_MINUS_2025.yaml
+++ b/data/COMPASS_KA_MINUS_2025.yaml
@@ -1,0 +1,2352 @@
+dependent_variables:
+  - header: {title: COMPASS $K^-$ Multiplicities}
+    qualifiers:
+      - {name: process, value: SIDIS}
+      - {name: observable, value: dsigma/dxdydz}
+      - {name: target_isoscalarity, value: 1.0}
+      - {name: prefactor, value: 1}
+      - {name: Vs, value: 17.35}
+      - {name: Q, low: 0.9, high: 8.0, integrate: true}
+      - {name: x, low: 0.004, high: 0.4, integrate: true}
+      - {name: z, low: 0.2, high: 0.85, integrate: true}
+      - {name: PS_reduction, W: 5, ymin: 0.1, ymax: 0.7}
+      - {name: hadron, value: KA}
+      - {name: charge, value: -1}
+    values:
+      - errors:
+          - {label: unc, value: 0.0147}
+          - {label: add, value: 0.04683}
+        value: 0.32837
+      - errors:
+          - {label: unc, value: 0.01152}
+          - {label: add, value: 0.04661}
+        value: 0.24748
+      - errors:
+          - {label: unc, value: 0.00898}
+          - {label: add, value: 0.04681}
+        value: 0.17844
+      - errors:
+          - {label: unc, value: 0.00763}
+          - {label: add, value: 0.04766}
+        value: 0.13949
+      - errors:
+          - {label: unc, value: 0.00615}
+          - {label: add, value: 0.05105}
+        value: 0.10077
+      - errors:
+          - {label: unc, value: 0.00553}
+          - {label: add, value: 0.0551}
+        value: 0.08276
+      - errors:
+          - {label: unc, value: 0.00513}
+          - {label: add, value: 0.0597}
+        value: 0.0595
+      - errors:
+          - {label: unc, value: 0.00521}
+          - {label: add, value: 0.07156}
+        value: 0.0417
+      - errors:
+          - {label: unc, value: 0.0148}
+          - {label: add, value: 0.05}
+        value: 0.3504
+      - errors:
+          - {label: unc, value: 0.01146}
+          - {label: add, value: 0.05019}
+        value: 0.2592
+      - errors:
+          - {label: unc, value: 0.00909}
+          - {label: add, value: 0.05077}
+        value: 0.19366
+      - errors:
+          - {label: unc, value: 0.008}
+          - {label: add, value: 0.05078}
+        value: 0.14936
+      - errors:
+          - {label: unc, value: 0.00966}
+          - {label: add, value: 0.05422}
+        value: 0.13442
+      - errors:
+          - {label: unc, value: 0.01213}
+          - {label: add, value: 0.04822}
+        value: 0.09208
+      - errors:
+          - {label: unc, value: 0.00705}
+          - {label: add, value: 0.05474}
+        value: 0.06182
+      - errors:
+          - {label: unc, value: 0.00629}
+          - {label: add, value: 0.05856}
+        value: 0.05137
+      - errors:
+          - {label: unc, value: 0.00549}
+          - {label: add, value: 0.07859}
+        value: 0.03746
+      - errors:
+          - {label: unc, value: 0.00436}
+          - {label: add, value: 0.06407}
+        value: 0.02697
+      - errors:
+          - {label: unc, value: 0.0043}
+          - {label: add, value: 0.04638}
+        value: 0.02277
+      - errors:
+          - {label: unc, value: 0.00539}
+          - {label: add, value: 0.04608}
+        value: 0.02795
+      - errors:
+          - {label: unc, value: 0.00159}
+          - {label: add, value: 0.05623}
+        value: 0.00626
+      - errors:
+          - {label: unc, value: 0.00768}
+          - {label: add, value: 0.04402}
+        value: 0.16464
+      - errors:
+          - {label: unc, value: 0.00557}
+          - {label: add, value: 0.04518}
+        value: 0.12502
+      - errors:
+          - {label: unc, value: 0.0043}
+          - {label: add, value: 0.04776}
+        value: 0.09078
+      - errors:
+          - {label: unc, value: 0.00377}
+          - {label: add, value: 0.05019}
+        value: 0.0746
+      - errors:
+          - {label: unc, value: 0.00296}
+          - {label: add, value: 0.05514}
+        value: 0.05165
+      - errors:
+          - {label: unc, value: 0.00249}
+          - {label: add, value: 0.06229}
+        value: 0.03866
+      - errors:
+          - {label: unc, value: 0.00195}
+          - {label: add, value: 0.05537}
+        value: 0.02875
+      - errors:
+          - {label: unc, value: 0.00159}
+          - {label: add, value: 0.04686}
+        value: 0.02168
+      - errors:
+          - {label: unc, value: 0.00146}
+          - {label: add, value: 0.04719}
+        value: 0.01763
+      - errors:
+          - {label: unc, value: 0.0009}
+          - {label: add, value: 0.04749}
+        value: 0.01196
+      - errors:
+          - {label: unc, value: 0.01273}
+          - {label: add, value: 0.04468}
+        value: 0.32965
+      - errors:
+          - {label: unc, value: 0.00876}
+          - {label: add, value: 0.04461}
+        value: 0.23562
+      - errors:
+          - {label: unc, value: 0.00697}
+          - {label: add, value: 0.04477}
+        value: 0.18281
+      - errors:
+          - {label: unc, value: 0.00551}
+          - {label: add, value: 0.04516}
+        value: 0.1387
+      - errors:
+          - {label: unc, value: 0.00449}
+          - {label: add, value: 0.0472}
+        value: 0.10577
+      - errors:
+          - {label: unc, value: 0.00347}
+          - {label: add, value: 0.04864}
+        value: 0.07599
+      - errors:
+          - {label: unc, value: 0.00295}
+          - {label: add, value: 0.05227}
+        value: 0.05755
+      - errors:
+          - {label: unc, value: 0.00271}
+          - {label: add, value: 0.05911}
+        value: 0.04534
+      - errors:
+          - {label: unc, value: 0.00241}
+          - {label: add, value: 0.05642}
+        value: 0.03559
+      - errors:
+          - {label: unc, value: 0.00211}
+          - {label: add, value: 0.04727}
+        value: 0.02454
+      - errors:
+          - {label: unc, value: 0.00215}
+          - {label: add, value: 0.04628}
+        value: 0.01746
+      - errors:
+          - {label: unc, value: 0.01406}
+          - {label: add, value: 0.04652}
+        value: 0.34413
+      - errors:
+          - {label: unc, value: 0.011}
+          - {label: add, value: 0.04664}
+        value: 0.25506
+      - errors:
+          - {label: unc, value: 0.00902}
+          - {label: add, value: 0.04747}
+        value: 0.19564
+      - errors:
+          - {label: unc, value: 0.00747}
+          - {label: add, value: 0.04833}
+        value: 0.13788
+      - errors:
+          - {label: unc, value: 0.00798}
+          - {label: add, value: 0.04852}
+        value: 0.1131
+      - errors:
+          - {label: unc, value: 0.00407}
+          - {label: add, value: 0.06734}
+        value: 0.02982
+      - errors:
+          - {label: unc, value: 0.00285}
+          - {label: add, value: 0.05651}
+        value: 0.0235
+      - errors:
+          - {label: unc, value: 0.00238}
+          - {label: add, value: 0.04769}
+        value: 0.01862
+      - errors:
+          - {label: unc, value: 0.00216}
+          - {label: add, value: 0.04632}
+        value: 0.01468
+      - errors:
+          - {label: unc, value: 0.00114}
+          - {label: add, value: 0.04747}
+        value: 0.00792
+      - errors:
+          - {label: unc, value: 0.00421}
+          - {label: add, value: 0.0482}
+        value: 0.0649
+      - errors:
+          - {label: unc, value: 0.00311}
+          - {label: add, value: 0.05397}
+        value: 0.04906
+      - errors:
+          - {label: unc, value: 0.00239}
+          - {label: add, value: 0.06143}
+        value: 0.03308
+      - errors:
+          - {label: unc, value: 0.00221}
+          - {label: add, value: 0.05419}
+        value: 0.03041
+      - errors:
+          - {label: unc, value: 0.00175}
+          - {label: add, value: 0.04551}
+        value: 0.02127
+      - errors:
+          - {label: unc, value: 0.00133}
+          - {label: add, value: 0.04695}
+        value: 0.01329
+      - errors:
+          - {label: unc, value: 0.00085}
+          - {label: add, value: 0.04513}
+        value: 0.00975
+      - errors:
+          - {label: unc, value: 0.00878}
+          - {label: add, value: 0.04315}
+        value: 0.16278
+      - errors:
+          - {label: unc, value: 0.00595}
+          - {label: add, value: 0.04385}
+        value: 0.12681
+      - errors:
+          - {label: unc, value: 0.00424}
+          - {label: add, value: 0.04495}
+        value: 0.08756
+      - errors:
+          - {label: unc, value: 0.0037}
+          - {label: add, value: 0.04615}
+        value: 0.07176
+      - errors:
+          - {label: unc, value: 0.00287}
+          - {label: add, value: 0.04799}
+        value: 0.05018
+      - errors:
+          - {label: unc, value: 0.00252}
+          - {label: add, value: 0.05178}
+        value: 0.04017
+      - errors:
+          - {label: unc, value: 0.00207}
+          - {label: add, value: 0.04988}
+        value: 0.03015
+      - errors:
+          - {label: unc, value: 0.00174}
+          - {label: add, value: 0.04587}
+        value: 0.0225
+      - errors:
+          - {label: unc, value: 0.00145}
+          - {label: add, value: 0.04633}
+        value: 0.01623
+      - errors:
+          - {label: unc, value: 0.00096}
+          - {label: add, value: 0.04694}
+        value: 0.0121
+      - errors:
+          - {label: unc, value: 0.01484}
+          - {label: add, value: 0.04374}
+        value: 0.32687
+      - errors:
+          - {label: unc, value: 0.01015}
+          - {label: add, value: 0.04346}
+        value: 0.24521
+      - errors:
+          - {label: unc, value: 0.00814}
+          - {label: add, value: 0.04361}
+        value: 0.18713
+      - errors:
+          - {label: unc, value: 0.00641}
+          - {label: add, value: 0.04382}
+        value: 0.13693
+      - errors:
+          - {label: unc, value: 0.00509}
+          - {label: add, value: 0.04463}
+        value: 0.09985
+      - errors:
+          - {label: unc, value: 0.00409}
+          - {label: add, value: 0.0459}
+        value: 0.07199
+      - errors:
+          - {label: unc, value: 0.00384}
+          - {label: add, value: 0.04773}
+        value: 0.06084
+      - errors:
+          - {label: unc, value: 0.00351}
+          - {label: add, value: 0.0509}
+        value: 0.04621
+      - errors:
+          - {label: unc, value: 0.00314}
+          - {label: add, value: 0.05069}
+        value: 0.0333
+      - errors:
+          - {label: unc, value: 0.00313}
+          - {label: add, value: 0.04837}
+        value: 0.02448
+      - errors:
+          - {label: unc, value: 0.00306}
+          - {label: add, value: 0.06989}
+        value: 0.01591
+      - errors:
+          - {label: unc, value: 0.01786}
+          - {label: add, value: 0.04546}
+        value: 0.36147
+      - errors:
+          - {label: unc, value: 0.01381}
+          - {label: add, value: 0.04584}
+        value: 0.24867
+      - errors:
+          - {label: unc, value: 0.01248}
+          - {label: add, value: 0.04709}
+        value: 0.2059
+      - errors:
+          - {label: unc, value: 0.0096}
+          - {label: add, value: 0.04801}
+        value: 0.12232
+      - errors:
+          - {label: unc, value: 0.01219}
+          - {label: add, value: 0.04906}
+        value: 0.11724
+      - errors:
+          - {label: unc, value: 0.00432}
+          - {label: add, value: 0.05514}
+        value: 0.03003
+      - errors:
+          - {label: unc, value: 0.00267}
+          - {label: add, value: 0.05099}
+        value: 0.02416
+      - errors:
+          - {label: unc, value: 0.00196}
+          - {label: add, value: 0.04552}
+        value: 0.0181
+      - errors:
+          - {label: unc, value: 0.00154}
+          - {label: add, value: 0.04543}
+        value: 0.01444
+      - errors:
+          - {label: unc, value: 0.00078}
+          - {label: add, value: 0.04597}
+        value: 0.00818
+      - errors:
+          - {label: unc, value: 0.0052}
+          - {label: add, value: 0.04663}
+        value: 0.06193
+      - errors:
+          - {label: unc, value: 0.00338}
+          - {label: add, value: 0.0498}
+        value: 0.04225
+      - errors:
+          - {label: unc, value: 0.00291}
+          - {label: add, value: 0.05114}
+        value: 0.03551
+      - errors:
+          - {label: unc, value: 0.00265}
+          - {label: add, value: 0.04919}
+        value: 0.03025
+      - errors:
+          - {label: unc, value: 0.00217}
+          - {label: add, value: 0.04553}
+        value: 0.02091
+      - errors:
+          - {label: unc, value: 0.00189}
+          - {label: add, value: 0.04495}
+        value: 0.01584
+      - errors:
+          - {label: unc, value: 0.00089}
+          - {label: add, value: 0.04513}
+        value: 0.0078
+      - errors:
+          - {label: unc, value: 0.01056}
+          - {label: add, value: 0.04272}
+        value: 0.15449
+      - errors:
+          - {label: unc, value: 0.00688}
+          - {label: add, value: 0.04348}
+        value: 0.11813
+      - errors:
+          - {label: unc, value: 0.005}
+          - {label: add, value: 0.04382}
+        value: 0.08598
+      - errors:
+          - {label: unc, value: 0.00453}
+          - {label: add, value: 0.04508}
+        value: 0.07151
+      - errors:
+          - {label: unc, value: 0.0034}
+          - {label: add, value: 0.04517}
+        value: 0.04693
+      - errors:
+          - {label: unc, value: 0.00292}
+          - {label: add, value: 0.04696}
+        value: 0.03748
+      - errors:
+          - {label: unc, value: 0.00267}
+          - {label: add, value: 0.04637}
+        value: 0.03019
+      - errors:
+          - {label: unc, value: 0.00203}
+          - {label: add, value: 0.04563}
+        value: 0.01876
+      - errors:
+          - {label: unc, value: 0.00176}
+          - {label: add, value: 0.04652}
+        value: 0.0141
+      - errors:
+          - {label: unc, value: 0.00098}
+          - {label: add, value: 0.04752}
+        value: 0.00825
+      - errors:
+          - {label: unc, value: 0.01754}
+          - {label: add, value: 0.0435}
+        value: 0.3187
+      - errors:
+          - {label: unc, value: 0.01167}
+          - {label: add, value: 0.04337}
+        value: 0.24217
+      - errors:
+          - {label: unc, value: 0.0096}
+          - {label: add, value: 0.04347}
+        value: 0.18605
+      - errors:
+          - {label: unc, value: 0.00759}
+          - {label: add, value: 0.04408}
+        value: 0.13284
+      - errors:
+          - {label: unc, value: 0.00594}
+          - {label: add, value: 0.04543}
+        value: 0.0914
+      - errors:
+          - {label: unc, value: 0.00514}
+          - {label: add, value: 0.04644}
+        value: 0.07132
+      - errors:
+          - {label: unc, value: 0.00491}
+          - {label: add, value: 0.04847}
+        value: 0.05793
+      - errors:
+          - {label: unc, value: 0.00373}
+          - {label: add, value: 0.04754}
+        value: 0.035
+      - errors:
+          - {label: unc, value: 0.00428}
+          - {label: add, value: 0.05379}
+        value: 0.03376
+      - errors:
+          - {label: unc, value: 0.00346}
+          - {label: add, value: 0.04829}
+        value: 0.01756
+      - errors:
+          - {label: unc, value: 0.00641}
+          - {label: add, value: 0.06839}
+        value: 0.02866
+      - errors:
+          - {label: unc, value: 0.02146}
+          - {label: add, value: 0.04482}
+        value: 0.33182
+      - errors:
+          - {label: unc, value: 0.01983}
+          - {label: add, value: 0.04543}
+        value: 0.27999
+      - errors:
+          - {label: unc, value: 0.01539}
+          - {label: add, value: 0.04692}
+        value: 0.18193
+      - errors:
+          - {label: unc, value: 0.01316}
+          - {label: add, value: 0.04711}
+        value: 0.12175
+      - errors:
+          - {label: unc, value: 0.01474}
+          - {label: add, value: 0.0532}
+        value: 0.09143
+      - errors:
+          - {label: unc, value: 0.00319}
+          - {label: add, value: 0.04554}
+        value: 0.03074
+      - errors:
+          - {label: unc, value: 0.00188}
+          - {label: add, value: 0.04574}
+        value: 0.01679
+      - errors:
+          - {label: unc, value: 0.00133}
+          - {label: add, value: 0.04476}
+        value: 0.01144
+      - errors:
+          - {label: unc, value: 0.00064}
+          - {label: add, value: 0.04698}
+        value: 0.0063
+      - errors:
+          - {label: unc, value: 0.00525}
+          - {label: add, value: 0.04373}
+        value: 0.06312
+      - errors:
+          - {label: unc, value: 0.00337}
+          - {label: add, value: 0.04499}
+        value: 0.04428
+      - errors:
+          - {label: unc, value: 0.00272}
+          - {label: add, value: 0.04707}
+        value: 0.03331
+      - errors:
+          - {label: unc, value: 0.00278}
+          - {label: add, value: 0.04607}
+        value: 0.03299
+      - errors:
+          - {label: unc, value: 0.00206}
+          - {label: add, value: 0.04465}
+        value: 0.01989
+      - errors:
+          - {label: unc, value: 0.00167}
+          - {label: add, value: 0.0467}
+        value: 0.01302
+      - errors:
+          - {label: unc, value: 0.0008}
+          - {label: add, value: 0.04431}
+        value: 0.0065
+      - errors:
+          - {label: unc, value: 0.01044}
+          - {label: add, value: 0.04291}
+        value: 0.15103
+      - errors:
+          - {label: unc, value: 0.00713}
+          - {label: add, value: 0.04366}
+        value: 0.12479
+      - errors:
+          - {label: unc, value: 0.00474}
+          - {label: add, value: 0.04345}
+        value: 0.07936
+      - errors:
+          - {label: unc, value: 0.00425}
+          - {label: add, value: 0.04394}
+        value: 0.06682
+      - errors:
+          - {label: unc, value: 0.00336}
+          - {label: add, value: 0.04461}
+        value: 0.04645
+      - errors:
+          - {label: unc, value: 0.00302}
+          - {label: add, value: 0.04641}
+        value: 0.03792
+      - errors:
+          - {label: unc, value: 0.00243}
+          - {label: add, value: 0.0454}
+        value: 0.02731
+      - errors:
+          - {label: unc, value: 0.00193}
+          - {label: add, value: 0.04514}
+        value: 0.01719
+      - errors:
+          - {label: unc, value: 0.00164}
+          - {label: add, value: 0.04713}
+        value: 0.01273
+      - errors:
+          - {label: unc, value: 0.00086}
+          - {label: add, value: 0.05199}
+        value: 0.00677
+      - errors:
+          - {label: unc, value: 0.01784}
+          - {label: add, value: 0.0435}
+        value: 0.31893
+      - errors:
+          - {label: unc, value: 0.01168}
+          - {label: add, value: 0.04312}
+        value: 0.24082
+      - errors:
+          - {label: unc, value: 0.00858}
+          - {label: add, value: 0.04343}
+        value: 0.16082
+      - errors:
+          - {label: unc, value: 0.00713}
+          - {label: add, value: 0.04355}
+        value: 0.12161
+      - errors:
+          - {label: unc, value: 0.00577}
+          - {label: add, value: 0.04429}
+        value: 0.0876
+      - errors:
+          - {label: unc, value: 0.00481}
+          - {label: add, value: 0.04577}
+        value: 0.0652
+      - errors:
+          - {label: unc, value: 0.00396}
+          - {label: add, value: 0.04693}
+        value: 0.04381
+      - errors:
+          - {label: unc, value: 0.00444}
+          - {label: add, value: 0.05169}
+        value: 0.04426
+      - errors:
+          - {label: unc, value: 0.00441}
+          - {label: add, value: 0.05705}
+        value: 0.03548
+      - errors:
+          - {label: unc, value: 0.00344}
+          - {label: add, value: 0.05404}
+        value: 0.01969
+      - errors:
+          - {label: unc, value: 0.0029}
+          - {label: add, value: 0.04936}
+        value: 0.01021
+      - errors:
+          - {label: unc, value: 0.02432}
+          - {label: add, value: 0.04345}
+        value: 0.35354
+      - errors:
+          - {label: unc, value: 0.02054}
+          - {label: add, value: 0.04426}
+        value: 0.2684
+      - errors:
+          - {label: unc, value: 0.01661}
+          - {label: add, value: 0.04456}
+        value: 0.18186
+      - errors:
+          - {label: unc, value: 0.01436}
+          - {label: add, value: 0.04574}
+        value: 0.11893
+      - errors:
+          - {label: unc, value: 0.01869}
+          - {label: add, value: 0.05459}
+        value: 0.11665
+      - errors:
+          - {label: unc, value: 0.00269}
+          - {label: add, value: 0.0449}
+        value: 0.01871
+      - errors:
+          - {label: unc, value: 0.00183}
+          - {label: add, value: 0.04413}
+        value: 0.01287
+      - errors:
+          - {label: unc, value: 0.00145}
+          - {label: add, value: 0.04479}
+        value: 0.01018
+      - errors:
+          - {label: unc, value: 0.00072}
+          - {label: add, value: 0.04706}
+        value: 0.00595
+      - errors:
+          - {label: unc, value: 0.00528}
+          - {label: add, value: 0.04369}
+        value: 0.05237
+      - errors:
+          - {label: unc, value: 0.00376}
+          - {label: add, value: 0.04372}
+        value: 0.04227
+      - errors:
+          - {label: unc, value: 0.00289}
+          - {label: add, value: 0.04444}
+        value: 0.02862
+      - errors:
+          - {label: unc, value: 0.00231}
+          - {label: add, value: 0.04514}
+        value: 0.01985
+      - errors:
+          - {label: unc, value: 0.00219}
+          - {label: add, value: 0.04501}
+        value: 0.01653
+      - errors:
+          - {label: unc, value: 0.0017}
+          - {label: add, value: 0.04457}
+        value: 0.01059
+      - errors:
+          - {label: unc, value: 0.0008}
+          - {label: add, value: 0.04496}
+        value: 0.00516
+      - errors:
+          - {label: unc, value: 0.01346}
+          - {label: add, value: 0.04233}
+        value: 0.18843
+      - errors:
+          - {label: unc, value: 0.00651}
+          - {label: add, value: 0.04232}
+        value: 0.09717
+      - errors:
+          - {label: unc, value: 0.00489}
+          - {label: add, value: 0.0429}
+        value: 0.07328
+      - errors:
+          - {label: unc, value: 0.00401}
+          - {label: add, value: 0.04316}
+        value: 0.05283
+      - errors:
+          - {label: unc, value: 0.00369}
+          - {label: add, value: 0.04446}
+        value: 0.04552
+      - errors:
+          - {label: unc, value: 0.00267}
+          - {label: add, value: 0.04336}
+        value: 0.02712
+      - errors:
+          - {label: unc, value: 0.00257}
+          - {label: add, value: 0.04457}
+        value: 0.02387
+      - errors:
+          - {label: unc, value: 0.00192}
+          - {label: add, value: 0.04546}
+        value: 0.01531
+      - errors:
+          - {label: unc, value: 0.00167}
+          - {label: add, value: 0.0509}
+        value: 0.01116
+      - errors:
+          - {label: unc, value: 0.00099}
+          - {label: add, value: 0.05042}
+        value: 0.00714
+      - errors:
+          - {label: unc, value: 0.02305}
+          - {label: add, value: 0.04291}
+        value: 0.36095
+      - errors:
+          - {label: unc, value: 0.01225}
+          - {label: add, value: 0.04252}
+        value: 0.22241
+      - errors:
+          - {label: unc, value: 0.00973}
+          - {label: add, value: 0.04301}
+        value: 0.1607
+      - errors:
+          - {label: unc, value: 0.00774}
+          - {label: add, value: 0.04309}
+        value: 0.11289
+      - errors:
+          - {label: unc, value: 0.00648}
+          - {label: add, value: 0.04421}
+        value: 0.08396
+      - errors:
+          - {label: unc, value: 0.00497}
+          - {label: add, value: 0.04695}
+        value: 0.05435
+      - errors:
+          - {label: unc, value: 0.00469}
+          - {label: add, value: 0.04585}
+        value: 0.04467
+      - errors:
+          - {label: unc, value: 0.00406}
+          - {label: add, value: 0.0484}
+        value: 0.03058
+      - errors:
+          - {label: unc, value: 0.00457}
+          - {label: add, value: 0.06557}
+        value: 0.03038
+      - errors:
+          - {label: unc, value: 0.00373}
+          - {label: add, value: 0.05309}
+        value: 0.01552
+      - errors:
+          - {label: unc, value: 0.00322}
+          - {label: add, value: 0.04843}
+        value: 0.00859
+      - errors:
+          - {label: unc, value: 0.03467}
+          - {label: add, value: 0.04357}
+        value: 0.40875
+      - errors:
+          - {label: unc, value: 0.02519}
+          - {label: add, value: 0.04328}
+        value: 0.23715
+      - errors:
+          - {label: unc, value: 0.02155}
+          - {label: add, value: 0.04555}
+        value: 0.17861
+      - errors:
+          - {label: unc, value: 0.02324}
+          - {label: add, value: 0.04738}
+        value: 0.16496
+      - errors:
+          - {label: unc, value: 0.0117}
+          - {label: add, value: 0.15306}
+        value: 0.02906
+      - errors:
+          - {label: unc, value: 0.00473}
+          - {label: add, value: 0.0431}
+        value: 0.01615
+      - errors:
+          - {label: unc, value: 0.00267}
+          - {label: add, value: 0.04519}
+        value: 0.00956
+      - errors:
+          - {label: unc, value: 0.00264}
+          - {label: add, value: 0.0441}
+        value: 0.01034
+      - errors:
+          - {label: unc, value: 0.00133}
+          - {label: add, value: 0.04829}
+        value: 0.00613
+      - errors:
+          - {label: unc, value: 0.00593}
+          - {label: add, value: 0.0425}
+        value: 0.02805
+      - errors:
+          - {label: unc, value: 0.00463}
+          - {label: add, value: 0.04332}
+        value: 0.02604
+      - errors:
+          - {label: unc, value: 0.00422}
+          - {label: add, value: 0.04324}
+        value: 0.02516
+      - errors:
+          - {label: unc, value: 0.00321}
+          - {label: add, value: 0.04451}
+        value: 0.01456
+      - errors:
+          - {label: unc, value: 0.00277}
+          - {label: add, value: 0.04674}
+        value: 0.01044
+      - errors:
+          - {label: unc, value: 0.00234}
+          - {label: add, value: 0.07326}
+        value: 0.00677
+      - errors:
+          - {label: unc, value: 0.00048}
+          - {label: add, value: 0.25455}
+        value: 0.00066
+      - errors:
+          - {label: unc, value: 0.01715}
+          - {label: add, value: 0.04203}
+        value: 0.13132
+      - errors:
+          - {label: unc, value: 0.00986}
+          - {label: add, value: 0.04167}
+        value: 0.0933
+      - errors:
+          - {label: unc, value: 0.0066}
+          - {label: add, value: 0.04203}
+        value: 0.05863
+      - errors:
+          - {label: unc, value: 0.00598}
+          - {label: add, value: 0.04498}
+        value: 0.04642
+      - errors:
+          - {label: unc, value: 0.00468}
+          - {label: add, value: 0.04288}
+        value: 0.0319
+      - errors:
+          - {label: unc, value: 0.00359}
+          - {label: add, value: 0.04198}
+        value: 0.01982
+      - errors:
+          - {label: unc, value: 0.00351}
+          - {label: add, value: 0.04336}
+        value: 0.01974
+      - errors:
+          - {label: unc, value: 0.00264}
+          - {label: add, value: 0.04614}
+        value: 0.01023
+      - errors:
+          - {label: unc, value: 0.00151}
+          - {label: add, value: 0.16527}
+        value: 0.00334
+      - errors:
+          - {label: unc, value: 0.0012}
+          - {label: add, value: 0.06531}
+        value: 0.00441
+      - errors:
+          - {label: unc, value: 0.03497}
+          - {label: add, value: 0.04317}
+        value: 0.2911
+      - errors:
+          - {label: unc, value: 0.01971}
+          - {label: add, value: 0.04197}
+        value: 0.22321
+      - errors:
+          - {label: unc, value: 0.01487}
+          - {label: add, value: 0.04211}
+        value: 0.14324
+      - errors:
+          - {label: unc, value: 0.01166}
+          - {label: add, value: 0.04253}
+        value: 0.09762
+      - errors:
+          - {label: unc, value: 0.0087}
+          - {label: add, value: 0.04316}
+        value: 0.05931
+      - errors:
+          - {label: unc, value: 0.00991}
+          - {label: add, value: 0.04558}
+        value: 0.06512
+      - errors:
+          - {label: unc, value: 0.00663}
+          - {label: add, value: 0.04413}
+        value: 0.03281
+      - errors:
+          - {label: unc, value: 0.00615}
+          - {label: add, value: 0.04792}
+        value: 0.02287
+      - errors:
+          - {label: unc, value: 0.00843}
+          - {label: add, value: 0.06496}
+        value: 0.03005
+      - errors:
+          - {label: unc, value: 0.01123}
+          - {label: add, value: 0.01907}
+        value: 0.02433
+      - errors:
+          - {label: unc, value: 0.04716}
+          - {label: add, value: 0.04588}
+        value: 0.25909
+      - errors:
+          - {label: unc, value: 0.05023}
+          - {label: add, value: 0.04641}
+        value: 0.25647
+      - errors:
+          - {label: unc, value: 0.0447}
+          - {label: add, value: 0.0443}
+        value: 0.19448
+      - errors:
+          - {label: unc, value: 0.02375}
+          - {label: add, value: 0.04735}
+        value: 0.06826
+      - errors:
+          - {label: unc, value: 0.00515}
+          - {label: add, value: 0.05119}
+        value: 0.01047
+      - errors:
+          - {label: unc, value: 0.00904}
+          - {label: add, value: 0.019}
+        value: 0.01726
+      - errors:
+          - {label: unc, value: 0.00497}
+          - {label: add, value: 0.04562}
+        value: 0.0128
+      - errors:
+          - {label: unc, value: 0.00201}
+          - {label: add, value: 0.04481}
+        value: 0.00482
+      - errors:
+          - {label: unc, value: 0.00807}
+          - {label: add, value: 0.0505}
+        value: 0.02487
+      - errors:
+          - {label: unc, value: 0.00918}
+          - {label: add, value: 0.04217}
+        value: 0.0351
+      - errors:
+          - {label: unc, value: 0.00241}
+          - {label: add, value: 0.16147}
+        value: 0.00327
+      - errors:
+          - {label: unc, value: 0.00379}
+          - {label: add, value: 0.10485}
+        value: 0.00763
+      - errors:
+          - {label: unc, value: 0.00357}
+          - {label: add, value: 0.04888}
+        value: 0.00851
+      - errors:
+          - {label: unc, value: 0.00425}
+          - {label: add, value: 0.01931}
+        value: 0.0058
+      - errors:
+          - {label: unc, value: 0.00089}
+          - {label: add, value: 0.08148}
+        value: 0.00108
+      - errors:
+          - {label: unc, value: 0.02573}
+          - {label: add, value: 0.0422}
+        value: 0.13592
+      - errors:
+          - {label: unc, value: 0.01572}
+          - {label: add, value: 0.04197}
+        value: 0.09722
+      - errors:
+          - {label: unc, value: 0.00909}
+          - {label: add, value: 0.04259}
+        value: 0.0479
+      - errors:
+          - {label: unc, value: 0.00702}
+          - {label: add, value: 0.04594}
+        value: 0.03065
+      - errors:
+          - {label: unc, value: 0.00739}
+          - {label: add, value: 0.04429}
+        value: 0.03125
+      - errors:
+          - {label: unc, value: 0.00577}
+          - {label: add, value: 0.04495}
+        value: 0.02118
+      - errors:
+          - {label: unc, value: 0.00465}
+          - {label: add, value: 0.04612}
+        value: 0.01561
+      - errors:
+          - {label: unc, value: 0.00467}
+          - {label: add, value: 0.06055}
+        value: 0.01374
+      - errors:
+          - {label: unc, value: 0.00349}
+          - {label: add, value: 0.02373}
+        value: 0.00472
+      - errors:
+          - {label: unc, value: 0.00207}
+          - {label: add, value: 0.01972}
+        value: 0.00284
+      - errors:
+          - {label: unc, value: 0.04307}
+          - {label: add, value: 0.04273}
+        value: 0.20782
+      - errors:
+          - {label: unc, value: 0.02839}
+          - {label: add, value: 0.04172}
+        value: 0.19637
+      - errors:
+          - {label: unc, value: 0.02029}
+          - {label: add, value: 0.04275}
+        value: 0.11302
+      - errors:
+          - {label: unc, value: 0.02014}
+          - {label: add, value: 0.04267}
+        value: 0.1093
+      - errors:
+          - {label: unc, value: 0.01514}
+          - {label: add, value: 0.04665}
+        value: 0.05934
+      - errors:
+          - {label: unc, value: 0.00994}
+          - {label: add, value: 0.04577}
+        value: 0.03059
+      - errors:
+          - {label: unc, value: 0.00707}
+          - {label: add, value: 0.07}
+        value: 0.0152
+      - errors:
+          - {label: unc, value: 0.00937}
+          - {label: add, value: 0.07254}
+        value: 0.0193
+      - errors:
+          - {label: unc, value: 0.11987}
+          - {label: add, value: 0.04371}
+        value: 0.43778
+      - errors:
+          - {label: unc, value: 0.04182}
+          - {label: add, value: 0.11332}
+        value: 0.07201
+      - errors:
+          - {label: unc, value: 0.04838}
+          - {label: add, value: 0.0496}
+        value: 0.11241
+      - errors:
+          - {label: unc, value: 0.01197}
+          - {label: add, value: 0.04178}
+        value: 0.036
+      - errors:
+          - {label: unc, value: 0.00505}
+          - {label: add, value: 0.04214}
+        value: 0.01215
+      - errors:
+          - {label: unc, value: 0.00556}
+          - {label: add, value: 0.04205}
+        value: 0.01427
+      - errors:
+          - {label: unc, value: 0.00544}
+          - {label: add, value: 0.04689}
+        value: 0.01433
+      - errors:
+          - {label: unc, value: 0.00331}
+          - {label: add, value: 0.02007}
+        value: 0.00279
+      - errors:
+          - {label: unc, value: 0.00272}
+          - {label: add, value: 0.05}
+        value: 0.00416
+      - errors:
+          - {label: unc, value: 0.00228}
+          - {label: add, value: 0.04384}
+        value: 0.00438
+      - errors:
+          - {label: unc, value: 0.02301}
+          - {label: add, value: 0.05113}
+        value: 0.09952
+      - errors:
+          - {label: unc, value: 0.01607}
+          - {label: add, value: 0.04318}
+        value: 0.09134
+      - errors:
+          - {label: unc, value: 0.00856}
+          - {label: add, value: 0.04912}
+        value: 0.04137
+      - errors:
+          - {label: unc, value: 0.00791}
+          - {label: add, value: 0.04256}
+        value: 0.03421
+      - errors:
+          - {label: unc, value: 0.00646}
+          - {label: add, value: 0.04195}
+        value: 0.0246
+      - errors:
+          - {label: unc, value: 0.0044}
+          - {label: add, value: 0.05082}
+        value: 0.01165
+      - errors:
+          - {label: unc, value: 0.00255}
+          - {label: add, value: 0.07885}
+        value: 0.00416
+      - errors:
+          - {label: unc, value: 0.00278}
+          - {label: add, value: 0.04668}
+        value: 0.00497
+      - errors:
+          - {label: unc, value: 0.00434}
+          - {label: add, value: 0.04383}
+        value: 0.0115
+      - errors:
+          - {label: unc, value: 0.00166}
+          - {label: add, value: 0.06957}
+        value: 0.00345
+      - errors:
+          - {label: unc, value: 0.06509}
+          - {label: add, value: 0.04174}
+        value: 0.38544
+      - errors:
+          - {label: unc, value: 0.02894}
+          - {label: add, value: 0.04151}
+        value: 0.19062
+      - errors:
+          - {label: unc, value: 0.02316}
+          - {label: add, value: 0.04211}
+        value: 0.14627
+      - errors:
+          - {label: unc, value: 0.01568}
+          - {label: add, value: 0.04166}
+        value: 0.07336
+      - errors:
+          - {label: unc, value: 0.0128}
+          - {label: add, value: 0.04363}
+        value: 0.05024
+      - errors:
+          - {label: unc, value: 0.01232}
+          - {label: add, value: 0.05683}
+        value: 0.04688
+      - errors:
+          - {label: unc, value: 0.00939}
+          - {label: add, value: 0.04489}
+        value: 0.02495
+      - errors:
+          - {label: unc, value: 0.01412}
+          - {label: add, value: 0.02247}
+        value: 0.0235
+      - errors:
+          - {label: unc, value: 0.1087}
+          - {label: add, value: 0.06245}
+        value: 0.23033
+      - errors:
+          - {label: unc, value: 0.07209}
+          - {label: add, value: 0.09271}
+        value: 0.11442
+independent_variables:
+  - header: {name: z}
+    values:
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+  - header: {name: x}
+    values:
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+  - header: {name: y}
+    values:
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+  - header: {name: Q2}
+    values:
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 28.89816}
+      - {value: 28.89816}
+      - {value: 28.89816}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 52.377915}
+      - {value: 52.377915}

--- a/data/COMPASS_KA_MINUS_2026.yaml
+++ b/data/COMPASS_KA_MINUS_2026.yaml
@@ -1,0 +1,2464 @@
+dependent_variables:
+  - header: {title: COMPASS $K^-$ Multiplicities}
+    qualifiers:
+      - {name: process, value: SIDIS}
+      - {name: observable, value: dsigma/dxdydz}
+      - {name: target_isoscalarity, value: 0.5}
+      - {name: prefactor, value: 1}
+      - {name: Vs, value: 17.35}
+      - {name: Q, low: 0.9, high: 6.0, integrate: true}
+      - {name: x, low: 0.004, high: 0.4, integrate: true}
+      - {name: z, low: 0.2, high: 0.85, integrate: true}
+      - {name: PS_reduction, W: 5, ymin: 0.1, ymax: 0.7}
+      - {name: hadron, value: KA}
+      - {name: charge, value: -1}
+    values:
+      - errors:
+          - {label: unc, value: 0.01687}
+          - {label: add, value: 0.0588}
+        value: 0.3415
+      - errors:
+          - {label: unc, value: 0.01333}
+          - {label: add, value: 0.05852}
+        value: 0.2652
+      - errors:
+          - {label: unc, value: 0.01117}
+          - {label: add, value: 0.0581}
+        value: 0.2148
+      - errors:
+          - {label: unc, value: 0.00779}
+          - {label: add, value: 0.05726}
+        value: 0.1411
+      - errors:
+          - {label: unc, value: 0.00696}
+          - {label: add, value: 0.0599}
+        value: 0.1162
+      - errors:
+          - {label: unc, value: 0.00563}
+          - {label: add, value: 0.06263}
+        value: 0.0843
+      - errors:
+          - {label: unc, value: 0.00576}
+          - {label: add, value: 0.08253}
+        value: 0.0601
+      - errors:
+          - {label: unc, value: 0.00673}
+          - {label: add, value: 0.08636}
+        value: 0.0528
+      - errors:
+          - {label: unc, value: 0.00854}
+          - {label: add, value: 0.10417}
+        value: 0.0384
+      - errors:
+          - {label: unc, value: 0.01153}
+          - {label: add, value: 0.13647}
+        value: 0.017
+      - errors:
+          - {label: unc, value: 0.01851}
+          - {label: add, value: 0.06399}
+        value: 0.3713
+      - errors:
+          - {label: unc, value: 0.01395}
+          - {label: add, value: 0.06358}
+        value: 0.2768
+      - errors:
+          - {label: unc, value: 0.0106}
+          - {label: add, value: 0.06339}
+        value: 0.2057
+      - errors:
+          - {label: unc, value: 0.00824}
+          - {label: add, value: 0.0625}
+        value: 0.1472
+      - errors:
+          - {label: unc, value: 0.0078}
+          - {label: add, value: 0.06337}
+        value: 0.1073
+      - errors:
+          - {label: unc, value: 0.0104}
+          - {label: add, value: 0.05364}
+        value: 0.0865
+      - errors:
+          - {label: unc, value: 0.00796}
+          - {label: add, value: 0.05248}
+        value: 0.0808
+      - errors:
+          - {label: unc, value: 0.00646}
+          - {label: add, value: 0.06342}
+        value: 0.0555
+      - errors:
+          - {label: unc, value: 0.00519}
+          - {label: add, value: 0.06502}
+        value: 0.0406
+      - errors:
+          - {label: unc, value: 0.00445}
+          - {label: add, value: 0.04984}
+        value: 0.0305
+      - errors:
+          - {label: unc, value: 0.00349}
+          - {label: add, value: 0.04815}
+        value: 0.0216
+      - errors:
+          - {label: unc, value: 0.00337}
+          - {label: add, value: 0.05057}
+        value: 0.0174
+      - errors:
+          - {label: unc, value: 0.00195}
+          - {label: add, value: 0.05045}
+        value: 0.0111
+      - errors:
+          - {label: unc, value: 0.00893}
+          - {label: add, value: 0.05301}
+        value: 0.1826
+      - errors:
+          - {label: unc, value: 0.00592}
+          - {label: add, value: 0.05182}
+        value: 0.1266
+      - errors:
+          - {label: unc, value: 0.00489}
+          - {label: add, value: 0.05467}
+        value: 0.0995
+      - errors:
+          - {label: unc, value: 0.00383}
+          - {label: add, value: 0.05651}
+        value: 0.0722
+      - errors:
+          - {label: unc, value: 0.00322}
+          - {label: add, value: 0.05895}
+        value: 0.057
+      - errors:
+          - {label: unc, value: 0.00286}
+          - {label: add, value: 0.06607}
+        value: 0.0448
+      - errors:
+          - {label: unc, value: 0.00227}
+          - {label: add, value: 0.0565}
+        value: 0.0354
+      - errors:
+          - {label: unc, value: 0.00178}
+          - {label: add, value: 0.05203}
+        value: 0.0246
+      - errors:
+          - {label: unc, value: 0.00152}
+          - {label: add, value: 0.06228}
+        value: 0.0167
+      - errors:
+          - {label: unc, value: 0.00123}
+          - {label: add, value: 0.08889}
+        value: 0.0126
+      - errors:
+          - {label: unc, value: 0.0157}
+          - {label: add, value: 0.05766}
+        value: 0.3441
+      - errors:
+          - {label: unc, value: 0.01124}
+          - {label: add, value: 0.05618}
+        value: 0.2549
+      - errors:
+          - {label: unc, value: 0.00877}
+          - {label: add, value: 0.05579}
+        value: 0.1979
+      - errors:
+          - {label: unc, value: 0.00656}
+          - {label: add, value: 0.05542}
+        value: 0.1458
+      - errors:
+          - {label: unc, value: 0.00491}
+          - {label: add, value: 0.05649}
+        value: 0.1048
+      - errors:
+          - {label: unc, value: 0.00417}
+          - {label: add, value: 0.05674}
+        value: 0.086
+      - errors:
+          - {label: unc, value: 0.00345}
+          - {label: add, value: 0.06364}
+        value: 0.0616
+      - errors:
+          - {label: unc, value: 0.0031}
+          - {label: add, value: 0.07015}
+        value: 0.0479
+      - errors:
+          - {label: unc, value: 0.00279}
+          - {label: add, value: 0.07577}
+        value: 0.0359
+      - errors:
+          - {label: unc, value: 0.00281}
+          - {label: add, value: 0.09219}
+        value: 0.0269
+      - errors:
+          - {label: unc, value: 0.00316}
+          - {label: add, value: 0.09836}
+        value: 0.0244
+      - errors:
+          - {label: unc, value: 0.01837}
+          - {label: add, value: 0.06401}
+        value: 0.3687
+      - errors:
+          - {label: unc, value: 0.01391}
+          - {label: add, value: 0.06372}
+        value: 0.2762
+      - errors:
+          - {label: unc, value: 0.01034}
+          - {label: add, value: 0.06306}
+        value: 0.2017
+      - errors:
+          - {label: unc, value: 0.00818}
+          - {label: add, value: 0.06232}
+        value: 0.1502
+      - errors:
+          - {label: unc, value: 0.00743}
+          - {label: add, value: 0.06486}
+        value: 0.111
+      - errors:
+          - {label: unc, value: 0.0039}
+          - {label: add, value: 0.06309}
+        value: 0.0317
+      - errors:
+          - {label: unc, value: 0.00367}
+          - {label: add, value: 0.05041}
+        value: 0.0365
+      - errors:
+          - {label: unc, value: 0.00231}
+          - {label: add, value: 0.04571}
+        value: 0.021
+      - errors:
+          - {label: unc, value: 0.00198}
+          - {label: add, value: 0.04557}
+        value: 0.0158
+      - errors:
+          - {label: unc, value: 0.00104}
+          - {label: add, value: 0.04819}
+        value: 0.0083
+      - errors:
+          - {label: unc, value: 0.00828}
+          - {label: add, value: 0.05061}
+        value: 0.098
+      - errors:
+          - {label: unc, value: 0.00426}
+          - {label: add, value: 0.05263}
+        value: 0.0684
+      - errors:
+          - {label: unc, value: 0.0032}
+          - {label: add, value: 0.05533}
+        value: 0.0535
+      - errors:
+          - {label: unc, value: 0.00269}
+          - {label: add, value: 0.06}
+        value: 0.04
+      - errors:
+          - {label: unc, value: 0.00205}
+          - {label: add, value: 0.0517}
+        value: 0.0294
+      - errors:
+          - {label: unc, value: 0.00166}
+          - {label: add, value: 0.04776}
+        value: 0.0201
+      - errors:
+          - {label: unc, value: 0.00141}
+          - {label: add, value: 0.04737}
+        value: 0.0152
+      - errors:
+          - {label: unc, value: 0.00088}
+          - {label: add, value: 0.04706}
+        value: 0.0102
+      - errors:
+          - {label: unc, value: 0.00948}
+          - {label: add, value: 0.05058}
+        value: 0.1819
+      - errors:
+          - {label: unc, value: 0.00642}
+          - {label: add, value: 0.04985}
+        value: 0.1364
+      - errors:
+          - {label: unc, value: 0.00492}
+          - {label: add, value: 0.05044}
+        value: 0.1031
+      - errors:
+          - {label: unc, value: 0.00388}
+          - {label: add, value: 0.05007}
+        value: 0.0767
+      - errors:
+          - {label: unc, value: 0.00328}
+          - {label: add, value: 0.05226}
+        value: 0.0597
+      - errors:
+          - {label: unc, value: 0.00266}
+          - {label: add, value: 0.05781}
+        value: 0.0429
+      - errors:
+          - {label: unc, value: 0.00215}
+          - {label: add, value: 0.05269}
+        value: 0.0334
+      - errors:
+          - {label: unc, value: 0.00175}
+          - {label: add, value: 0.04781}
+        value: 0.0251
+      - errors:
+          - {label: unc, value: 0.00132}
+          - {label: add, value: 0.0518}
+        value: 0.0139
+      - errors:
+          - {label: unc, value: 0.00108}
+          - {label: add, value: 0.06667}
+        value: 0.012
+      - errors:
+          - {label: unc, value: 0.01558}
+          - {label: add, value: 0.05585}
+        value: 0.3323
+      - errors:
+          - {label: unc, value: 0.01178}
+          - {label: add, value: 0.05422}
+        value: 0.2656
+      - errors:
+          - {label: unc, value: 0.00872}
+          - {label: add, value: 0.05386}
+        value: 0.1931
+      - errors:
+          - {label: unc, value: 0.00695}
+          - {label: add, value: 0.0538}
+        value: 0.1487
+      - errors:
+          - {label: unc, value: 0.00525}
+          - {label: add, value: 0.05353}
+        value: 0.1091
+      - errors:
+          - {label: unc, value: 0.00431}
+          - {label: add, value: 0.0534}
+        value: 0.0839
+      - errors:
+          - {label: unc, value: 0.00388}
+          - {label: add, value: 0.05899}
+        value: 0.0651
+      - errors:
+          - {label: unc, value: 0.00378}
+          - {label: add, value: 0.06506}
+        value: 0.0541
+      - errors:
+          - {label: unc, value: 0.00312}
+          - {label: add, value: 0.06739}
+        value: 0.0368
+      - errors:
+          - {label: unc, value: 0.00363}
+          - {label: add, value: 0.09749}
+        value: 0.0279
+      - errors:
+          - {label: unc, value: 0.00361}
+          - {label: add, value: 0.06809}
+        value: 0.0235
+      - errors:
+          - {label: unc, value: 0.01829}
+          - {label: add, value: 0.06248}
+        value: 0.3521
+      - errors:
+          - {label: unc, value: 0.01508}
+          - {label: add, value: 0.06217}
+        value: 0.2831
+      - errors:
+          - {label: unc, value: 0.01144}
+          - {label: add, value: 0.06205}
+        value: 0.2037
+      - errors:
+          - {label: unc, value: 0.00904}
+          - {label: add, value: 0.06089}
+        value: 0.1419
+      - errors:
+          - {label: unc, value: 0.01002}
+          - {label: add, value: 0.0612}
+        value: 0.1255
+      - errors:
+          - {label: unc, value: 0.00482}
+          - {label: add, value: 0.0555}
+        value: 0.0418
+      - errors:
+          - {label: unc, value: 0.00268}
+          - {label: add, value: 0.0483}
+        value: 0.0265
+      - errors:
+          - {label: unc, value: 0.0018}
+          - {label: add, value: 0.0442}
+        value: 0.0181
+      - errors:
+          - {label: unc, value: 0.00148}
+          - {label: add, value: 0.04238}
+        value: 0.0151
+      - errors:
+          - {label: unc, value: 0.00065}
+          - {label: add, value: 0.04384}
+        value: 0.0073
+      - errors:
+          - {label: unc, value: 0.01045}
+          - {label: add, value: 0.04791}
+        value: 0.0935
+      - errors:
+          - {label: unc, value: 0.00493}
+          - {label: add, value: 0.04706}
+        value: 0.0629
+      - errors:
+          - {label: unc, value: 0.00373}
+          - {label: add, value: 0.04876}
+        value: 0.0525
+      - errors:
+          - {label: unc, value: 0.0031}
+          - {label: add, value: 0.056}
+        value: 0.04
+      - errors:
+          - {label: unc, value: 0.00242}
+          - {label: add, value: 0.04706}
+        value: 0.0289
+      - errors:
+          - {label: unc, value: 0.00192}
+          - {label: add, value: 0.04583}
+        value: 0.0192
+      - errors:
+          - {label: unc, value: 0.00156}
+          - {label: add, value: 0.04746}
+        value: 0.0118
+      - errors:
+          - {label: unc, value: 0.00095}
+          - {label: add, value: 0.04819}
+        value: 0.0083
+      - errors:
+          - {label: unc, value: 0.00964}
+          - {label: add, value: 0.04916}
+        value: 0.1676
+      - errors:
+          - {label: unc, value: 0.0069}
+          - {label: add, value: 0.04839}
+        value: 0.1339
+      - errors:
+          - {label: unc, value: 0.00525}
+          - {label: add, value: 0.04887}
+        value: 0.1015
+      - errors:
+          - {label: unc, value: 0.00427}
+          - {label: add, value: 0.04821}
+        value: 0.078
+      - errors:
+          - {label: unc, value: 0.00323}
+          - {label: add, value: 0.04885}
+        value: 0.0524
+      - errors:
+          - {label: unc, value: 0.00278}
+          - {label: add, value: 0.05049}
+        value: 0.0412
+      - errors:
+          - {label: unc, value: 0.0023}
+          - {label: add, value: 0.05}
+        value: 0.0304
+      - errors:
+          - {label: unc, value: 0.00185}
+          - {label: add, value: 0.04729}
+        value: 0.0203
+      - errors:
+          - {label: unc, value: 0.00166}
+          - {label: add, value: 0.06275}
+        value: 0.0153
+      - errors:
+          - {label: unc, value: 0.00108}
+          - {label: add, value: 0.05283}
+        value: 0.0106
+      - errors:
+          - {label: unc, value: 0.01801}
+          - {label: add, value: 0.05488}
+        value: 0.3688
+      - errors:
+          - {label: unc, value: 0.01204}
+          - {label: add, value: 0.05323}
+        value: 0.263
+      - errors:
+          - {label: unc, value: 0.00947}
+          - {label: add, value: 0.05286}
+        value: 0.2013
+      - errors:
+          - {label: unc, value: 0.00764}
+          - {label: add, value: 0.05272}
+        value: 0.1563
+      - errors:
+          - {label: unc, value: 0.00584}
+          - {label: add, value: 0.05248}
+        value: 0.1128
+      - errors:
+          - {label: unc, value: 0.00462}
+          - {label: add, value: 0.05314}
+        value: 0.0813
+      - errors:
+          - {label: unc, value: 0.00403}
+          - {label: add, value: 0.05621}
+        value: 0.0612
+      - errors:
+          - {label: unc, value: 0.0038}
+          - {label: add, value: 0.06527}
+        value: 0.0478
+      - errors:
+          - {label: unc, value: 0.00362}
+          - {label: add, value: 0.06757}
+        value: 0.0367
+      - errors:
+          - {label: unc, value: 0.00348}
+          - {label: add, value: 0.0736}
+        value: 0.025
+      - errors:
+          - {label: unc, value: 0.00366}
+          - {label: add, value: 0.0766}
+        value: 0.0188
+      - errors:
+          - {label: unc, value: 0.01984}
+          - {label: add, value: 0.06176}
+        value: 0.3536
+      - errors:
+          - {label: unc, value: 0.01638}
+          - {label: add, value: 0.06205}
+        value: 0.2772
+      - errors:
+          - {label: unc, value: 0.01301}
+          - {label: add, value: 0.06117}
+        value: 0.2027
+      - errors:
+          - {label: unc, value: 0.01138}
+          - {label: add, value: 0.06203}
+        value: 0.1496
+      - errors:
+          - {label: unc, value: 0.01175}
+          - {label: add, value: 0.0617}
+        value: 0.1141
+      - errors:
+          - {label: unc, value: 0.00478}
+          - {label: add, value: 0.05118}
+        value: 0.0422
+      - errors:
+          - {label: unc, value: 0.00256}
+          - {label: add, value: 0.04669}
+        value: 0.0257
+      - errors:
+          - {label: unc, value: 0.0018}
+          - {label: add, value: 0.04124}
+        value: 0.0194
+      - errors:
+          - {label: unc, value: 0.00137}
+          - {label: add, value: 0.04275}
+        value: 0.0131
+      - errors:
+          - {label: unc, value: 0.00055}
+          - {label: add, value: 0.04324}
+        value: 0.0074
+      - errors:
+          - {label: unc, value: 0.00979}
+          - {label: add, value: 0.04642}
+        value: 0.1034
+      - errors:
+          - {label: unc, value: 0.00463}
+          - {label: add, value: 0.04609}
+        value: 0.0677
+      - errors:
+          - {label: unc, value: 0.00348}
+          - {label: add, value: 0.04563}
+        value: 0.0561
+      - errors:
+          - {label: unc, value: 0.00257}
+          - {label: add, value: 0.04718}
+        value: 0.0373
+      - errors:
+          - {label: unc, value: 0.0021}
+          - {label: add, value: 0.04545}
+        value: 0.0264
+      - errors:
+          - {label: unc, value: 0.00171}
+          - {label: add, value: 0.04469}
+        value: 0.0179
+      - errors:
+          - {label: unc, value: 0.00146}
+          - {label: add, value: 0.04242}
+        value: 0.0132
+      - errors:
+          - {label: unc, value: 0.00097}
+          - {label: add, value: 0.04848}
+        value: 0.0099
+      - errors:
+          - {label: unc, value: 0.00955}
+          - {label: add, value: 0.04822}
+        value: 0.1825
+      - errors:
+          - {label: unc, value: 0.00607}
+          - {label: add, value: 0.04735}
+        value: 0.1284
+      - errors:
+          - {label: unc, value: 0.00466}
+          - {label: add, value: 0.04779}
+        value: 0.0971
+      - errors:
+          - {label: unc, value: 0.00373}
+          - {label: add, value: 0.04751}
+        value: 0.0724
+      - errors:
+          - {label: unc, value: 0.00303}
+          - {label: add, value: 0.04774}
+        value: 0.0553
+      - errors:
+          - {label: unc, value: 0.00265}
+          - {label: add, value: 0.04898}
+        value: 0.0441
+      - errors:
+          - {label: unc, value: 0.00213}
+          - {label: add, value: 0.0475}
+        value: 0.032
+      - errors:
+          - {label: unc, value: 0.00166}
+          - {label: add, value: 0.04898}
+        value: 0.0196
+      - errors:
+          - {label: unc, value: 0.00155}
+          - {label: add, value: 0.04944}
+        value: 0.0178
+      - errors:
+          - {label: unc, value: 0.00082}
+          - {label: add, value: 0.05333}
+        value: 0.0105
+      - errors:
+          - {label: unc, value: 0.01631}
+          - {label: add, value: 0.05374}
+        value: 0.3439
+      - errors:
+          - {label: unc, value: 0.01159}
+          - {label: add, value: 0.05193}
+        value: 0.2619
+      - errors:
+          - {label: unc, value: 0.0087}
+          - {label: add, value: 0.05191}
+        value: 0.1911
+      - errors:
+          - {label: unc, value: 0.00655}
+          - {label: add, value: 0.05171}
+        value: 0.1377
+      - errors:
+          - {label: unc, value: 0.0052}
+          - {label: add, value: 0.05184}
+        value: 0.1034
+      - errors:
+          - {label: unc, value: 0.00409}
+          - {label: add, value: 0.05147}
+        value: 0.0746
+      - errors:
+          - {label: unc, value: 0.00353}
+          - {label: add, value: 0.054}
+        value: 0.0563
+      - errors:
+          - {label: unc, value: 0.00323}
+          - {label: add, value: 0.06052}
+        value: 0.0423
+      - errors:
+          - {label: unc, value: 0.00344}
+          - {label: add, value: 0.05773}
+        value: 0.0388
+      - errors:
+          - {label: unc, value: 0.00359}
+          - {label: add, value: 0.0967}
+        value: 0.0273
+      - errors:
+          - {label: unc, value: 0.00378}
+          - {label: add, value: 0.09187}
+        value: 0.0209
+      - errors:
+          - {label: unc, value: 0.02063}
+          - {label: add, value: 0.06021}
+        value: 0.3667
+      - errors:
+          - {label: unc, value: 0.01563}
+          - {label: add, value: 0.06019}
+        value: 0.2565
+      - errors:
+          - {label: unc, value: 0.01282}
+          - {label: add, value: 0.06049}
+        value: 0.1944
+      - errors:
+          - {label: unc, value: 0.01012}
+          - {label: add, value: 0.06016}
+        value: 0.125
+      - errors:
+          - {label: unc, value: 0.01153}
+          - {label: add, value: 0.05794}
+        value: 0.1146
+      - errors:
+          - {label: unc, value: 0.00408}
+          - {label: add, value: 0.04482}
+        value: 0.0357
+      - errors:
+          - {label: unc, value: 0.00235}
+          - {label: add, value: 0.04534}
+        value: 0.0247
+      - errors:
+          - {label: unc, value: 0.00178}
+          - {label: add, value: 0.04}
+        value: 0.018
+      - errors:
+          - {label: unc, value: 0.00137}
+          - {label: add, value: 0.04118}
+        value: 0.0136
+      - errors:
+          - {label: unc, value: 0.00053}
+          - {label: add, value: 0.0381}
+        value: 0.0063
+      - errors:
+          - {label: unc, value: 0.00806}
+          - {label: add, value: 0.04409}
+        value: 0.0889
+      - errors:
+          - {label: unc, value: 0.00379}
+          - {label: add, value: 0.04336}
+        value: 0.0572
+      - errors:
+          - {label: unc, value: 0.00286}
+          - {label: add, value: 0.04388}
+        value: 0.0474
+      - errors:
+          - {label: unc, value: 0.0023}
+          - {label: add, value: 0.04497}
+        value: 0.0338
+      - errors:
+          - {label: unc, value: 0.00187}
+          - {label: add, value: 0.04333}
+        value: 0.024
+      - errors:
+          - {label: unc, value: 0.00139}
+          - {label: add, value: 0.04571}
+        value: 0.014
+      - errors:
+          - {label: unc, value: 0.00125}
+          - {label: add, value: 0.04211}
+        value: 0.0114
+      - errors:
+          - {label: unc, value: 0.00053}
+          - {label: add, value: 0.04364}
+        value: 0.0055
+      - errors:
+          - {label: unc, value: 0.0085}
+          - {label: add, value: 0.04641}
+        value: 0.1672
+      - errors:
+          - {label: unc, value: 0.00551}
+          - {label: add, value: 0.04587}
+        value: 0.1186
+      - errors:
+          - {label: unc, value: 0.0043}
+          - {label: add, value: 0.04554}
+        value: 0.0931
+      - errors:
+          - {label: unc, value: 0.00327}
+          - {label: add, value: 0.04561}
+        value: 0.0649
+      - errors:
+          - {label: unc, value: 0.00254}
+          - {label: add, value: 0.04532}
+        value: 0.0459
+      - errors:
+          - {label: unc, value: 0.00196}
+          - {label: add, value: 0.04578}
+        value: 0.0332
+      - errors:
+          - {label: unc, value: 0.00175}
+          - {label: add, value: 0.04511}
+        value: 0.0266
+      - errors:
+          - {label: unc, value: 0.00134}
+          - {label: add, value: 0.04469}
+        value: 0.0179
+      - errors:
+          - {label: unc, value: 0.0012}
+          - {label: add, value: 0.04638}
+        value: 0.0138
+      - errors:
+          - {label: unc, value: 0.00067}
+          - {label: add, value: 0.04494}
+        value: 0.0089
+      - errors:
+          - {label: unc, value: 0.01663}
+          - {label: add, value: 0.052}
+        value: 0.3369
+      - errors:
+          - {label: unc, value: 0.01086}
+          - {label: add, value: 0.04988}
+        value: 0.2454
+      - errors:
+          - {label: unc, value: 0.00785}
+          - {label: add, value: 0.04991}
+        value: 0.1699
+      - errors:
+          - {label: unc, value: 0.0058}
+          - {label: add, value: 0.04983}
+        value: 0.1172
+      - errors:
+          - {label: unc, value: 0.00487}
+          - {label: add, value: 0.05038}
+        value: 0.0921
+      - errors:
+          - {label: unc, value: 0.0038}
+          - {label: add, value: 0.05077}
+        value: 0.0646
+      - errors:
+          - {label: unc, value: 0.00313}
+          - {label: add, value: 0.0519}
+        value: 0.0447
+      - errors:
+          - {label: unc, value: 0.0028}
+          - {label: add, value: 0.05517}
+        value: 0.0348
+      - errors:
+          - {label: unc, value: 0.00249}
+          - {label: add, value: 0.05333}
+        value: 0.024
+      - errors:
+          - {label: unc, value: 0.00319}
+          - {label: add, value: 0.0605}
+        value: 0.0238
+      - errors:
+          - {label: unc, value: 0.00321}
+          - {label: add, value: 0.064}
+        value: 0.0175
+      - errors:
+          - {label: unc, value: 0.02161}
+          - {label: add, value: 0.0589}
+        value: 0.3314
+      - errors:
+          - {label: unc, value: 0.01734}
+          - {label: add, value: 0.05841}
+        value: 0.2397
+      - errors:
+          - {label: unc, value: 0.01319}
+          - {label: add, value: 0.05934}
+        value: 0.1564
+      - errors:
+          - {label: unc, value: 0.01409}
+          - {label: add, value: 0.05785}
+        value: 0.1452
+      - errors:
+          - {label: unc, value: 0.01122}
+          - {label: add, value: 0.06521}
+        value: 0.0687
+      - errors:
+          - {label: unc, value: 0.00488}
+          - {label: add, value: 0.04348}
+        value: 0.0276
+      - errors:
+          - {label: unc, value: 0.00288}
+          - {label: add, value: 0.04356}
+        value: 0.0202
+      - errors:
+          - {label: unc, value: 0.00195}
+          - {label: add, value: 0.04308}
+        value: 0.013
+      - errors:
+          - {label: unc, value: 0.00143}
+          - {label: add, value: 0.0404}
+        value: 0.0099
+      - errors:
+          - {label: unc, value: 0.00061}
+          - {label: add, value: 0.04}
+        value: 0.004
+      - errors:
+          - {label: unc, value: 0.0097}
+          - {label: add, value: 0.04205}
+        value: 0.0761
+      - errors:
+          - {label: unc, value: 0.00448}
+          - {label: add, value: 0.04177}
+        value: 0.0498
+      - errors:
+          - {label: unc, value: 0.00289}
+          - {label: add, value: 0.04185}
+        value: 0.0325
+      - errors:
+          - {label: unc, value: 0.00245}
+          - {label: add, value: 0.04226}
+        value: 0.0265
+      - errors:
+          - {label: unc, value: 0.00211}
+          - {label: add, value: 0.044}
+        value: 0.02
+      - errors:
+          - {label: unc, value: 0.00145}
+          - {label: add, value: 0.04571}
+        value: 0.0105
+      - errors:
+          - {label: unc, value: 0.00133}
+          - {label: add, value: 0.04348}
+        value: 0.0092
+      - errors:
+          - {label: unc, value: 0.00063}
+          - {label: add, value: 0.05106}
+        value: 0.0047
+      - errors:
+          - {label: unc, value: 0.01099}
+          - {label: add, value: 0.0448}
+        value: 0.1643
+      - errors:
+          - {label: unc, value: 0.00644}
+          - {label: add, value: 0.04381}
+        value: 0.1114
+      - errors:
+          - {label: unc, value: 0.00435}
+          - {label: add, value: 0.04343}
+        value: 0.07
+      - errors:
+          - {label: unc, value: 0.00382}
+          - {label: add, value: 0.04391}
+        value: 0.0583
+      - errors:
+          - {label: unc, value: 0.00321}
+          - {label: add, value: 0.04381}
+        value: 0.042
+      - errors:
+          - {label: unc, value: 0.00252}
+          - {label: add, value: 0.04488}
+        value: 0.0303
+      - errors:
+          - {label: unc, value: 0.00215}
+          - {label: add, value: 0.04407}
+        value: 0.0236
+      - errors:
+          - {label: unc, value: 0.00178}
+          - {label: add, value: 0.045}
+        value: 0.016
+      - errors:
+          - {label: unc, value: 0.00125}
+          - {label: add, value: 0.05517}
+        value: 0.0087
+      - errors:
+          - {label: unc, value: 0.00072}
+          - {label: add, value: 0.05106}
+        value: 0.0047
+      - errors:
+          - {label: unc, value: 0.02413}
+          - {label: add, value: 0.04872}
+        value: 0.3481
+      - errors:
+          - {label: unc, value: 0.01222}
+          - {label: add, value: 0.04719}
+        value: 0.2136
+      - errors:
+          - {label: unc, value: 0.01002}
+          - {label: add, value: 0.04703}
+        value: 0.1633
+      - errors:
+          - {label: unc, value: 0.00749}
+          - {label: add, value: 0.04715}
+        value: 0.1052
+      - errors:
+          - {label: unc, value: 0.00632}
+          - {label: add, value: 0.04864}
+        value: 0.0806
+      - errors:
+          - {label: unc, value: 0.00487}
+          - {label: add, value: 0.0501}
+        value: 0.0495
+      - errors:
+          - {label: unc, value: 0.00444}
+          - {label: add, value: 0.05581}
+        value: 0.0344
+      - errors:
+          - {label: unc, value: 0.00416}
+          - {label: add, value: 0.05205}
+        value: 0.0292
+      - errors:
+          - {label: unc, value: 0.00327}
+          - {label: add, value: 0.05714}
+        value: 0.0154
+      - errors:
+          - {label: unc, value: 0.00438}
+          - {label: add, value: 0.06747}
+        value: 0.0166
+      - errors:
+          - {label: unc, value: 0.00376}
+          - {label: add, value: 0.08462}
+        value: 0.0104
+      - errors:
+          - {label: unc, value: 0.03288}
+          - {label: add, value: 0.05558}
+        value: 0.3066
+      - errors:
+          - {label: unc, value: 0.03043}
+          - {label: add, value: 0.05572}
+        value: 0.2613
+      - errors:
+          - {label: unc, value: 0.02314}
+          - {label: add, value: 0.0579}
+        value: 0.1506
+      - errors:
+          - {label: unc, value: 0.02194}
+          - {label: add, value: 0.05889}
+        value: 0.1277
+      - errors:
+          - {label: unc, value: 0.02688}
+          - {label: add, value: 0.06961}
+        value: 0.0862
+      - errors:
+          - {label: unc, value: 0.00586}
+          - {label: add, value: 0.04195}
+        value: 0.0267
+      - errors:
+          - {label: unc, value: 0.00404}
+          - {label: add, value: 0.04167}
+        value: 0.0192
+      - errors:
+          - {label: unc, value: 0.00201}
+          - {label: add, value: 0.03721}
+        value: 0.0086
+      - errors:
+          - {label: unc, value: 0.00182}
+          - {label: add, value: 0.03678}
+        value: 0.0087
+      - errors:
+          - {label: unc, value: 0.00061}
+          - {label: add, value: 0.05517}
+        value: 0.0029
+      - errors:
+          - {label: unc, value: 0.0105}
+          - {label: add, value: 0.04103}
+        value: 0.0468
+      - errors:
+          - {label: unc, value: 0.00652}
+          - {label: add, value: 0.04148}
+        value: 0.054
+      - errors:
+          - {label: unc, value: 0.00414}
+          - {label: add, value: 0.04103}
+        value: 0.0351
+      - errors:
+          - {label: unc, value: 0.00318}
+          - {label: add, value: 0.04156}
+        value: 0.0231
+      - errors:
+          - {label: unc, value: 0.00255}
+          - {label: add, value: 0.04183}
+        value: 0.0153
+      - errors:
+          - {label: unc, value: 0.00182}
+          - {label: add, value: 0.04651}
+        value: 0.0086
+      - errors:
+          - {label: unc, value: 0.00172}
+          - {label: add, value: 0.03951}
+        value: 0.0081
+      - errors:
+          - {label: unc, value: 0.00102}
+          - {label: add, value: 0.048}
+        value: 0.005
+      - errors:
+          - {label: unc, value: 0.01387}
+          - {label: add, value: 0.04333}
+        value: 0.1311
+      - errors:
+          - {label: unc, value: 0.00775}
+          - {label: add, value: 0.04248}
+        value: 0.0904
+      - errors:
+          - {label: unc, value: 0.006}
+          - {label: add, value: 0.04286}
+        value: 0.0672
+      - errors:
+          - {label: unc, value: 0.00435}
+          - {label: add, value: 0.04276}
+        value: 0.0449
+      - errors:
+          - {label: unc, value: 0.00365}
+          - {label: add, value: 0.04401}
+        value: 0.0309
+      - errors:
+          - {label: unc, value: 0.00332}
+          - {label: add, value: 0.04494}
+        value: 0.0267
+      - errors:
+          - {label: unc, value: 0.00204}
+          - {label: add, value: 0.04786}
+        value: 0.0117
+      - errors:
+          - {label: unc, value: 0.00204}
+          - {label: add, value: 0.05283}
+        value: 0.0106
+      - errors:
+          - {label: unc, value: 0.00204}
+          - {label: add, value: 0.05234}
+        value: 0.0107
+      - errors:
+          - {label: unc, value: 0.00106}
+          - {label: add, value: 0.10213}
+        value: 0.0047
+      - errors:
+          - {label: unc, value: 0.03248}
+          - {label: add, value: 0.04903}
+        value: 0.3182
+      - errors:
+          - {label: unc, value: 0.01649}
+          - {label: add, value: 0.04571}
+        value: 0.1995
+      - errors:
+          - {label: unc, value: 0.01223}
+          - {label: add, value: 0.04575}
+        value: 0.1294
+      - errors:
+          - {label: unc, value: 0.01114}
+          - {label: add, value: 0.04657}
+        value: 0.1065
+      - errors:
+          - {label: unc, value: 0.00716}
+          - {label: add, value: 0.04971}
+        value: 0.0515
+      - errors:
+          - {label: unc, value: 0.00763}
+          - {label: add, value: 0.05}
+        value: 0.0496
+      - errors:
+          - {label: unc, value: 0.00543}
+          - {label: add, value: 0.09043}
+        value: 0.023
+      - errors:
+          - {label: unc, value: 0.00588}
+          - {label: add, value: 0.08688}
+        value: 0.0221
+      - errors:
+          - {label: unc, value: 0.00551}
+          - {label: add, value: 0.13245}
+        value: 0.0151
+      - errors:
+          - {label: unc, value: 0.00515}
+          - {label: add, value: 0.08972}
+        value: 0.0107
+      - errors:
+          - {label: unc, value: 0.01044}
+          - {label: add, value: 0.12704}
+        value: 0.0233
+      - errors:
+          - {label: unc, value: 0.01211}
+          - {label: add, value: 0.03963}
+        value: 0.0545
+      - errors:
+          - {label: unc, value: 0.00573}
+          - {label: add, value: 0.0404}
+        value: 0.0396
+      - errors:
+          - {label: unc, value: 0.00337}
+          - {label: add, value: 0.03929}
+        value: 0.0224
+      - errors:
+          - {label: unc, value: 0.00285}
+          - {label: add, value: 0.0426}
+        value: 0.0169
+      - errors:
+          - {label: unc, value: 0.00233}
+          - {label: add, value: 0.0384}
+        value: 0.0125
+      - errors:
+          - {label: unc, value: 0.00182}
+          - {label: add, value: 0.03721}
+        value: 0.0086
+      - errors:
+          - {label: unc, value: 0.00182}
+          - {label: add, value: 0.04324}
+        value: 0.0074
+      - errors:
+          - {label: unc, value: 0.0007}
+          - {label: add, value: 0.03478}
+        value: 0.0023
+      - errors:
+          - {label: unc, value: 0.01551}
+          - {label: add, value: 0.04168}
+        value: 0.1382
+      - errors:
+          - {label: unc, value: 0.00784}
+          - {label: add, value: 0.0412}
+        value: 0.0835
+      - errors:
+          - {label: unc, value: 0.00579}
+          - {label: add, value: 0.04117}
+        value: 0.0583
+      - errors:
+          - {label: unc, value: 0.00393}
+          - {label: add, value: 0.04109}
+        value: 0.0331
+      - errors:
+          - {label: unc, value: 0.00328}
+          - {label: add, value: 0.04051}
+        value: 0.0237
+      - errors:
+          - {label: unc, value: 0.00275}
+          - {label: add, value: 0.04186}
+        value: 0.0172
+      - errors:
+          - {label: unc, value: 0.00214}
+          - {label: add, value: 0.0487}
+        value: 0.0115
+      - errors:
+          - {label: unc, value: 0.00163}
+          - {label: add, value: 0.05405}
+        value: 0.0074
+      - errors:
+          - {label: unc, value: 0.00131}
+          - {label: add, value: 0.05333}
+        value: 0.0045
+      - errors:
+          - {label: unc, value: 0.00071}
+          - {label: add, value: 0.09412}
+        value: 0.0017
+      - errors:
+          - {label: unc, value: 0.0314}
+          - {label: add, value: 0.04633}
+        value: 0.2849
+      - errors:
+          - {label: unc, value: 0.01705}
+          - {label: add, value: 0.04309}
+        value: 0.2061
+      - errors:
+          - {label: unc, value: 0.01284}
+          - {label: add, value: 0.04321}
+        value: 0.1407
+      - errors:
+          - {label: unc, value: 0.00879}
+          - {label: add, value: 0.04439}
+        value: 0.0775
+      - errors:
+          - {label: unc, value: 0.00745}
+          - {label: add, value: 0.04776}
+        value: 0.0536
+      - errors:
+          - {label: unc, value: 0.00879}
+          - {label: add, value: 0.04813}
+        value: 0.0615
+      - errors:
+          - {label: unc, value: 0.00399}
+          - {label: add, value: 0.0875}
+        value: 0.0128
+      - errors:
+          - {label: unc, value: 0.00354}
+          - {label: add, value: 0.08276}
+        value: 0.0087
+      - errors:
+          - {label: unc, value: 0.00373}
+          - {label: add, value: 0.128}
+        value: 0.005
+independent_variables:
+  - header: {name: z}
+    values:
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+  - header: {name: x}
+    values:
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+  - header: {name: y}
+    values:
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+  - header: {name: Q2}
+    values:
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}

--- a/data/COMPASS_KA_PLUS_2025.yaml
+++ b/data/COMPASS_KA_PLUS_2025.yaml
@@ -1,0 +1,2408 @@
+dependent_variables:
+  - header: {title: COMPASS $K^+$ Multiplicities}
+    qualifiers:
+      - {name: process, value: SIDIS}
+      - {name: observable, value: dsigma/dxdydz}
+      - {name: target_isoscalarity, value: 1.0}
+      - {name: prefactor, value: 1}
+      - {name: Vs, value: 17.35}
+      - {name: Q, low: 0.9, high: 8.0, integrate: true}
+      - {name: x, low: 0.004, high: 0.4, integrate: true}
+      - {name: z, low: 0.2, high: 0.85, integrate: true}
+      - {name: PS_reduction, W: 5, ymin: 0.1, ymax: 0.7}
+      - {name: hadron, value: KA}
+      - {name: charge, value: 1}
+    values:
+      - errors:
+          - {label: unc, value: 0.01746}
+          - {label: add, value: 0.04647}
+        value: 0.40681
+      - errors:
+          - {label: unc, value: 0.01347}
+          - {label: add, value: 0.04614}
+        value: 0.30444
+      - errors:
+          - {label: unc, value: 0.01186}
+          - {label: add, value: 0.04617}
+        value: 0.25644
+      - errors:
+          - {label: unc, value: 0.00907}
+          - {label: add, value: 0.04679}
+        value: 0.1797
+      - errors:
+          - {label: unc, value: 0.00793}
+          - {label: add, value: 0.04902}
+        value: 0.14638
+      - errors:
+          - {label: unc, value: 0.00756}
+          - {label: add, value: 0.05051}
+        value: 0.12972
+      - errors:
+          - {label: unc, value: 0.00718}
+          - {label: add, value: 0.05516}
+        value: 0.09905
+      - errors:
+          - {label: unc, value: 0.00714}
+          - {label: add, value: 0.05812}
+        value: 0.06813
+      - errors:
+          - {label: unc, value: 0.0169}
+          - {label: add, value: 0.04971}
+        value: 0.40813
+      - errors:
+          - {label: unc, value: 0.01351}
+          - {label: add, value: 0.04995}
+        value: 0.31487
+      - errors:
+          - {label: unc, value: 0.01065}
+          - {label: add, value: 0.05029}
+        value: 0.23656
+      - errors:
+          - {label: unc, value: 0.00969}
+          - {label: add, value: 0.05023}
+        value: 0.19177
+      - errors:
+          - {label: unc, value: 0.01078}
+          - {label: add, value: 0.05167}
+        value: 0.16225
+      - errors:
+          - {label: unc, value: 0.01408}
+          - {label: add, value: 0.04691}
+        value: 0.12739
+      - errors:
+          - {label: unc, value: 0.00972}
+          - {label: add, value: 0.04942}
+        value: 0.10409
+      - errors:
+          - {label: unc, value: 0.00824}
+          - {label: add, value: 0.04987}
+        value: 0.0786
+      - errors:
+          - {label: unc, value: 0.00837}
+          - {label: add, value: 0.057}
+        value: 0.07902
+      - errors:
+          - {label: unc, value: 0.00683}
+          - {label: add, value: 0.05495}
+        value: 0.05591
+      - errors:
+          - {label: unc, value: 0.0066}
+          - {label: add, value: 0.04552}
+        value: 0.05114
+      - errors:
+          - {label: unc, value: 0.00559}
+          - {label: add, value: 0.04502}
+        value: 0.03643
+      - errors:
+          - {label: unc, value: 0.00332}
+          - {label: add, value: 0.04535}
+        value: 0.0254
+      - errors:
+          - {label: unc, value: 0.00966}
+          - {label: add, value: 0.04357}
+        value: 0.22403
+      - errors:
+          - {label: unc, value: 0.00722}
+          - {label: add, value: 0.04415}
+        value: 0.17485
+      - errors:
+          - {label: unc, value: 0.00611}
+          - {label: add, value: 0.04572}
+        value: 0.14366
+      - errors:
+          - {label: unc, value: 0.00505}
+          - {label: add, value: 0.0473}
+        value: 0.11113
+      - errors:
+          - {label: unc, value: 0.00421}
+          - {label: add, value: 0.04944}
+        value: 0.08609
+      - errors:
+          - {label: unc, value: 0.00387}
+          - {label: add, value: 0.05439}
+        value: 0.07237
+      - errors:
+          - {label: unc, value: 0.00306}
+          - {label: add, value: 0.05111}
+        value: 0.05541
+      - errors:
+          - {label: unc, value: 0.00256}
+          - {label: add, value: 0.04595}
+        value: 0.04353
+      - errors:
+          - {label: unc, value: 0.00243}
+          - {label: add, value: 0.0475}
+        value: 0.0384
+      - errors:
+          - {label: unc, value: 0.00167}
+          - {label: add, value: 0.04878}
+        value: 0.02903
+      - errors:
+          - {label: unc, value: 0.01535}
+          - {label: add, value: 0.04431}
+        value: 0.41054
+      - errors:
+          - {label: unc, value: 0.01153}
+          - {label: add, value: 0.04419}
+        value: 0.3208
+      - errors:
+          - {label: unc, value: 0.009}
+          - {label: add, value: 0.04424}
+        value: 0.24504
+      - errors:
+          - {label: unc, value: 0.00733}
+          - {label: add, value: 0.04452}
+        value: 0.19405
+      - errors:
+          - {label: unc, value: 0.00566}
+          - {label: add, value: 0.04566}
+        value: 0.14226
+      - errors:
+          - {label: unc, value: 0.00513}
+          - {label: add, value: 0.0473}
+        value: 0.12228
+      - errors:
+          - {label: unc, value: 0.00449}
+          - {label: add, value: 0.04952}
+        value: 0.0987
+      - errors:
+          - {label: unc, value: 0.00383}
+          - {label: add, value: 0.05439}
+        value: 0.0731
+      - errors:
+          - {label: unc, value: 0.00358}
+          - {label: add, value: 0.05262}
+        value: 0.06324
+      - errors:
+          - {label: unc, value: 0.00349}
+          - {label: add, value: 0.04834}
+        value: 0.05329
+      - errors:
+          - {label: unc, value: 0.00346}
+          - {label: add, value: 0.05243}
+        value: 0.03723
+      - errors:
+          - {label: unc, value: 0.01691}
+          - {label: add, value: 0.04614}
+        value: 0.42688
+      - errors:
+          - {label: unc, value: 0.01353}
+          - {label: add, value: 0.04638}
+        value: 0.32672
+      - errors:
+          - {label: unc, value: 0.01116}
+          - {label: add, value: 0.04706}
+        value: 0.25497
+      - errors:
+          - {label: unc, value: 0.00948}
+          - {label: add, value: 0.0477}
+        value: 0.19118
+      - errors:
+          - {label: unc, value: 0.01008}
+          - {label: add, value: 0.04963}
+        value: 0.15878
+      - errors:
+          - {label: unc, value: 0.00564}
+          - {label: add, value: 0.05687}
+        value: 0.0543
+      - errors:
+          - {label: unc, value: 0.0046}
+          - {label: add, value: 0.05042}
+        value: 0.05331
+      - errors:
+          - {label: unc, value: 0.00397}
+          - {label: add, value: 0.04499}
+        value: 0.04428
+      - errors:
+          - {label: unc, value: 0.00368}
+          - {label: add, value: 0.04559}
+        value: 0.03896
+      - errors:
+          - {label: unc, value: 0.0023}
+          - {label: add, value: 0.04575}
+        value: 0.02798
+      - errors:
+          - {label: unc, value: 0.00584}
+          - {label: add, value: 0.04546}
+        value: 0.10699
+      - errors:
+          - {label: unc, value: 0.0042}
+          - {label: add, value: 0.04823}
+        value: 0.07912
+      - errors:
+          - {label: unc, value: 0.00393}
+          - {label: add, value: 0.05174}
+        value: 0.0705
+      - errors:
+          - {label: unc, value: 0.00337}
+          - {label: add, value: 0.04817}
+        value: 0.05813
+      - errors:
+          - {label: unc, value: 0.00321}
+          - {label: add, value: 0.04496}
+        value: 0.05338
+      - errors:
+          - {label: unc, value: 0.00259}
+          - {label: add, value: 0.04462}
+        value: 0.03944
+      - errors:
+          - {label: unc, value: 0.00182}
+          - {label: add, value: 0.04475}
+        value: 0.03164
+      - errors:
+          - {label: unc, value: 0.01129}
+          - {label: add, value: 0.04267}
+        value: 0.23532
+      - errors:
+          - {label: unc, value: 0.00853}
+          - {label: add, value: 0.04305}
+        value: 0.20276
+      - errors:
+          - {label: unc, value: 0.00637}
+          - {label: add, value: 0.04366}
+        value: 0.14969
+      - errors:
+          - {label: unc, value: 0.00521}
+          - {label: add, value: 0.04438}
+        value: 0.11518
+      - errors:
+          - {label: unc, value: 0.00438}
+          - {label: add, value: 0.04559}
+        value: 0.09089
+      - errors:
+          - {label: unc, value: 0.00388}
+          - {label: add, value: 0.04704}
+        value: 0.07568
+      - errors:
+          - {label: unc, value: 0.00334}
+          - {label: add, value: 0.04606}
+        value: 0.06096
+      - errors:
+          - {label: unc, value: 0.00269}
+          - {label: add, value: 0.04554}
+        value: 0.04444
+      - errors:
+          - {label: unc, value: 0.00251}
+          - {label: add, value: 0.04734}
+        value: 0.03819
+      - errors:
+          - {label: unc, value: 0.00166}
+          - {label: add, value: 0.04987}
+        value: 0.02743
+      - errors:
+          - {label: unc, value: 0.01819}
+          - {label: add, value: 0.04332}
+        value: 0.42698
+      - errors:
+          - {label: unc, value: 0.01291}
+          - {label: add, value: 0.04313}
+        value: 0.33
+      - errors:
+          - {label: unc, value: 0.01007}
+          - {label: add, value: 0.04309}
+        value: 0.24764
+      - errors:
+          - {label: unc, value: 0.0085}
+          - {label: add, value: 0.04319}
+        value: 0.19932
+      - errors:
+          - {label: unc, value: 0.00747}
+          - {label: add, value: 0.04414}
+        value: 0.16566
+      - errors:
+          - {label: unc, value: 0.00624}
+          - {label: add, value: 0.04537}
+        value: 0.12783
+      - errors:
+          - {label: unc, value: 0.00531}
+          - {label: add, value: 0.04674}
+        value: 0.09739
+      - errors:
+          - {label: unc, value: 0.00533}
+          - {label: add, value: 0.04851}
+        value: 0.08674
+      - errors:
+          - {label: unc, value: 0.00534}
+          - {label: add, value: 0.05128}
+        value: 0.07332
+      - errors:
+          - {label: unc, value: 0.00465}
+          - {label: add, value: 0.0509}
+        value: 0.04872
+      - errors:
+          - {label: unc, value: 0.00523}
+          - {label: add, value: 0.04992}
+        value: 0.04167
+      - errors:
+          - {label: unc, value: 0.02003}
+          - {label: add, value: 0.04526}
+        value: 0.42405
+      - errors:
+          - {label: unc, value: 0.01718}
+          - {label: add, value: 0.0455}
+        value: 0.33674
+      - errors:
+          - {label: unc, value: 0.01505}
+          - {label: add, value: 0.04642}
+        value: 0.27486
+      - errors:
+          - {label: unc, value: 0.01326}
+          - {label: add, value: 0.04787}
+        value: 0.1967
+      - errors:
+          - {label: unc, value: 0.01601}
+          - {label: add, value: 0.04922}
+        value: 0.17765
+      - errors:
+          - {label: unc, value: 0.0065}
+          - {label: add, value: 0.04975}
+        value: 0.06513
+      - errors:
+          - {label: unc, value: 0.00407}
+          - {label: add, value: 0.0459}
+        value: 0.0488
+      - errors:
+          - {label: unc, value: 0.00359}
+          - {label: add, value: 0.04448}
+        value: 0.0491
+      - errors:
+          - {label: unc, value: 0.00279}
+          - {label: add, value: 0.04437}
+        value: 0.03931
+      - errors:
+          - {label: unc, value: 0.00163}
+          - {label: add, value: 0.04572}
+        value: 0.02677
+      - errors:
+          - {label: unc, value: 0.00801}
+          - {label: add, value: 0.04431}
+        value: 0.12566
+      - errors:
+          - {label: unc, value: 0.00514}
+          - {label: add, value: 0.04468}
+        value: 0.08505
+      - errors:
+          - {label: unc, value: 0.00481}
+          - {label: add, value: 0.04625}
+        value: 0.0775
+      - errors:
+          - {label: unc, value: 0.00396}
+          - {label: add, value: 0.04567}
+        value: 0.05868
+      - errors:
+          - {label: unc, value: 0.00335}
+          - {label: add, value: 0.04409}
+        value: 0.04391
+      - errors:
+          - {label: unc, value: 0.00307}
+          - {label: add, value: 0.04427}
+        value: 0.03813
+      - errors:
+          - {label: unc, value: 0.0021}
+          - {label: add, value: 0.04486}
+        value: 0.03085
+      - errors:
+          - {label: unc, value: 0.01379}
+          - {label: add, value: 0.04204}
+        value: 0.23405
+      - errors:
+          - {label: unc, value: 0.00938}
+          - {label: add, value: 0.04268}
+        value: 0.18763
+      - errors:
+          - {label: unc, value: 0.00731}
+          - {label: add, value: 0.04286}
+        value: 0.14878
+      - errors:
+          - {label: unc, value: 0.00634}
+          - {label: add, value: 0.04385}
+        value: 0.11969
+      - errors:
+          - {label: unc, value: 0.00548}
+          - {label: add, value: 0.04387}
+        value: 0.09737
+      - errors:
+          - {label: unc, value: 0.00471}
+          - {label: add, value: 0.04506}
+        value: 0.07617
+      - errors:
+          - {label: unc, value: 0.00403}
+          - {label: add, value: 0.04505}
+        value: 0.06056
+      - errors:
+          - {label: unc, value: 0.00394}
+          - {label: add, value: 0.04575}
+        value: 0.05491
+      - errors:
+          - {label: unc, value: 0.00332}
+          - {label: add, value: 0.04953}
+        value: 0.04022
+      - errors:
+          - {label: unc, value: 0.00215}
+          - {label: add, value: 0.05376}
+        value: 0.02842
+      - errors:
+          - {label: unc, value: 0.02209}
+          - {label: add, value: 0.0431}
+        value: 0.44493
+      - errors:
+          - {label: unc, value: 0.01465}
+          - {label: add, value: 0.04277}
+        value: 0.33185
+      - errors:
+          - {label: unc, value: 0.01241}
+          - {label: add, value: 0.04303}
+        value: 0.26755
+      - errors:
+          - {label: unc, value: 0.01034}
+          - {label: add, value: 0.04371}
+        value: 0.20753
+      - errors:
+          - {label: unc, value: 0.00905}
+          - {label: add, value: 0.04422}
+        value: 0.16917
+      - errors:
+          - {label: unc, value: 0.00776}
+          - {label: add, value: 0.04569}
+        value: 0.13359
+      - errors:
+          - {label: unc, value: 0.00741}
+          - {label: add, value: 0.04871}
+        value: 0.11218
+      - errors:
+          - {label: unc, value: 0.00659}
+          - {label: add, value: 0.05121}
+        value: 0.08373
+      - errors:
+          - {label: unc, value: 0.00673}
+          - {label: add, value: 0.05362}
+        value: 0.07296
+      - errors:
+          - {label: unc, value: 0.00596}
+          - {label: add, value: 0.05613}
+        value: 0.04675
+      - errors:
+          - {label: unc, value: 0.00691}
+          - {label: add, value: 0.05205}
+        value: 0.0415
+      - errors:
+          - {label: unc, value: 0.02741}
+          - {label: add, value: 0.04452}
+        value: 0.48141
+      - errors:
+          - {label: unc, value: 0.02264}
+          - {label: add, value: 0.04515}
+        value: 0.34978
+      - errors:
+          - {label: unc, value: 0.02244}
+          - {label: add, value: 0.04635}
+        value: 0.32135
+      - errors:
+          - {label: unc, value: 0.02007}
+          - {label: add, value: 0.04869}
+        value: 0.23463
+      - errors:
+          - {label: unc, value: 0.02006}
+          - {label: add, value: 0.05318}
+        value: 0.15149
+      - errors:
+          - {label: unc, value: 0.00456}
+          - {label: add, value: 0.04381}
+        value: 0.05862
+      - errors:
+          - {label: unc, value: 0.00309}
+          - {label: add, value: 0.04437}
+        value: 0.04057
+      - errors:
+          - {label: unc, value: 0.00272}
+          - {label: add, value: 0.04402}
+        value: 0.03871
+      - errors:
+          - {label: unc, value: 0.00162}
+          - {label: add, value: 0.04475}
+        value: 0.02771
+      - errors:
+          - {label: unc, value: 0.00726}
+          - {label: add, value: 0.04237}
+        value: 0.1114
+      - errors:
+          - {label: unc, value: 0.00522}
+          - {label: add, value: 0.04327}
+        value: 0.0882
+      - errors:
+          - {label: unc, value: 0.00438}
+          - {label: add, value: 0.0439}
+        value: 0.07107
+      - errors:
+          - {label: unc, value: 0.00397}
+          - {label: add, value: 0.04419}
+        value: 0.05938
+      - errors:
+          - {label: unc, value: 0.00351}
+          - {label: add, value: 0.04354}
+        value: 0.04814
+      - errors:
+          - {label: unc, value: 0.00277}
+          - {label: add, value: 0.04424}
+        value: 0.03309
+      - errors:
+          - {label: unc, value: 0.0019}
+          - {label: add, value: 0.04412}
+        value: 0.02756
+      - errors:
+          - {label: unc, value: 0.01467}
+          - {label: add, value: 0.04216}
+        value: 0.25598
+      - errors:
+          - {label: unc, value: 0.01001}
+          - {label: add, value: 0.04255}
+        value: 0.207
+      - errors:
+          - {label: unc, value: 0.00726}
+          - {label: add, value: 0.04269}
+        value: 0.14804
+      - errors:
+          - {label: unc, value: 0.00639}
+          - {label: add, value: 0.04299}
+        value: 0.12263
+      - errors:
+          - {label: unc, value: 0.00572}
+          - {label: add, value: 0.04321}
+        value: 0.1046
+      - errors:
+          - {label: unc, value: 0.00494}
+          - {label: add, value: 0.04386}
+        value: 0.08281
+      - errors:
+          - {label: unc, value: 0.00433}
+          - {label: add, value: 0.04472}
+        value: 0.06727
+      - errors:
+          - {label: unc, value: 0.00373}
+          - {label: add, value: 0.04626}
+        value: 0.05154
+      - errors:
+          - {label: unc, value: 0.00311}
+          - {label: add, value: 0.04884}
+        value: 0.03784
+      - errors:
+          - {label: unc, value: 0.00208}
+          - {label: add, value: 0.05335}
+        value: 0.02744
+      - errors:
+          - {label: unc, value: 0.02342}
+          - {label: add, value: 0.04321}
+        value: 0.47235
+      - errors:
+          - {label: unc, value: 0.01525}
+          - {label: add, value: 0.04267}
+        value: 0.35003
+      - errors:
+          - {label: unc, value: 0.01261}
+          - {label: add, value: 0.04276}
+        value: 0.27636
+      - errors:
+          - {label: unc, value: 0.01095}
+          - {label: add, value: 0.0431}
+        value: 0.22442
+      - errors:
+          - {label: unc, value: 0.00901}
+          - {label: add, value: 0.04369}
+        value: 0.17046
+      - errors:
+          - {label: unc, value: 0.00807}
+          - {label: add, value: 0.04616}
+        value: 0.139
+      - errors:
+          - {label: unc, value: 0.00677}
+          - {label: add, value: 0.04711}
+        value: 0.10121
+      - errors:
+          - {label: unc, value: 0.00614}
+          - {label: add, value: 0.05282}
+        value: 0.07634
+      - errors:
+          - {label: unc, value: 0.00618}
+          - {label: add, value: 0.05621}
+        value: 0.06277
+      - errors:
+          - {label: unc, value: 0.00652}
+          - {label: add, value: 0.05285}
+        value: 0.05374
+      - errors:
+          - {label: unc, value: 0.00848}
+          - {label: add, value: 0.06457}
+        value: 0.05427
+      - errors:
+          - {label: unc, value: 0.02584}
+          - {label: add, value: 0.04362}
+        value: 0.40108
+      - errors:
+          - {label: unc, value: 0.02488}
+          - {label: add, value: 0.04392}
+        value: 0.36247
+      - errors:
+          - {label: unc, value: 0.02155}
+          - {label: add, value: 0.04529}
+        value: 0.27945
+      - errors:
+          - {label: unc, value: 0.02137}
+          - {label: add, value: 0.04744}
+        value: 0.23523
+      - errors:
+          - {label: unc, value: 0.02047}
+          - {label: add, value: 0.0514}
+        value: 0.1432
+      - errors:
+          - {label: unc, value: 0.00474}
+          - {label: add, value: 0.04272}
+        value: 0.05206
+      - errors:
+          - {label: unc, value: 0.00404}
+          - {label: add, value: 0.04307}
+        value: 0.05108
+      - errors:
+          - {label: unc, value: 0.00289}
+          - {label: add, value: 0.04335}
+        value: 0.03543
+      - errors:
+          - {label: unc, value: 0.00201}
+          - {label: add, value: 0.04453}
+        value: 0.03198
+      - errors:
+          - {label: unc, value: 0.00822}
+          - {label: add, value: 0.04176}
+        value: 0.11227
+      - errors:
+          - {label: unc, value: 0.0059}
+          - {label: add, value: 0.04304}
+        value: 0.08978
+      - errors:
+          - {label: unc, value: 0.00492}
+          - {label: add, value: 0.04325}
+        value: 0.07085
+      - errors:
+          - {label: unc, value: 0.00376}
+          - {label: add, value: 0.04298}
+        value: 0.04746
+      - errors:
+          - {label: unc, value: 0.00421}
+          - {label: add, value: 0.04361}
+        value: 0.05411
+      - errors:
+          - {label: unc, value: 0.00391}
+          - {label: add, value: 0.04411}
+        value: 0.04697
+      - errors:
+          - {label: unc, value: 0.00214}
+          - {label: add, value: 0.04424}
+        value: 0.02803
+      - errors:
+          - {label: unc, value: 0.01566}
+          - {label: add, value: 0.04171}
+        value: 0.25545
+      - errors:
+          - {label: unc, value: 0.01038}
+          - {label: add, value: 0.04195}
+        value: 0.20007
+      - errors:
+          - {label: unc, value: 0.00828}
+          - {label: add, value: 0.04198}
+        value: 0.16142
+      - errors:
+          - {label: unc, value: 0.00784}
+          - {label: add, value: 0.04231}
+        value: 0.14709
+      - errors:
+          - {label: unc, value: 0.00628}
+          - {label: add, value: 0.04256}
+        value: 0.10677
+      - errors:
+          - {label: unc, value: 0.00524}
+          - {label: add, value: 0.04259}
+        value: 0.08095
+      - errors:
+          - {label: unc, value: 0.00438}
+          - {label: add, value: 0.04405}
+        value: 0.06121
+      - errors:
+          - {label: unc, value: 0.00421}
+          - {label: add, value: 0.04695}
+        value: 0.05367
+      - errors:
+          - {label: unc, value: 0.0038}
+          - {label: add, value: 0.05066}
+        value: 0.0439
+      - errors:
+          - {label: unc, value: 0.00242}
+          - {label: add, value: 0.05842}
+        value: 0.02958
+      - errors:
+          - {label: unc, value: 0.02768}
+          - {label: add, value: 0.04246}
+        value: 0.48856
+      - errors:
+          - {label: unc, value: 0.01687}
+          - {label: add, value: 0.04254}
+        value: 0.3487
+      - errors:
+          - {label: unc, value: 0.01486}
+          - {label: add, value: 0.04239}
+        value: 0.30156
+      - errors:
+          - {label: unc, value: 0.01154}
+          - {label: add, value: 0.04245}
+        value: 0.21259
+      - errors:
+          - {label: unc, value: 0.0103}
+          - {label: add, value: 0.04339}
+        value: 0.17182
+      - errors:
+          - {label: unc, value: 0.0089}
+          - {label: add, value: 0.04593}
+        value: 0.13657
+      - errors:
+          - {label: unc, value: 0.00881}
+          - {label: add, value: 0.04997}
+        value: 0.11896
+      - errors:
+          - {label: unc, value: 0.0071}
+          - {label: add, value: 0.05696}
+        value: 0.07613
+      - errors:
+          - {label: unc, value: 0.00699}
+          - {label: add, value: 0.06225}
+        value: 0.06259
+      - errors:
+          - {label: unc, value: 0.00759}
+          - {label: add, value: 0.05654}
+        value: 0.05829
+      - errors:
+          - {label: unc, value: 0.00835}
+          - {label: add, value: 0.07173}
+        value: 0.04584
+      - errors:
+          - {label: unc, value: 0.03572}
+          - {label: add, value: 0.04334}
+        value: 0.45646
+      - errors:
+          - {label: unc, value: 0.03309}
+          - {label: add, value: 0.04329}
+        value: 0.38382
+      - errors:
+          - {label: unc, value: 0.02949}
+          - {label: add, value: 0.04434}
+        value: 0.2959
+      - errors:
+          - {label: unc, value: 0.03083}
+          - {label: add, value: 0.05209}
+        value: 0.26109
+      - errors:
+          - {label: unc, value: 0.02444}
+          - {label: add, value: 0.04857}
+        value: 0.13934
+      - errors:
+          - {label: unc, value: 0.0092}
+          - {label: add, value: 0.04335}
+        value: 0.06072
+      - errors:
+          - {label: unc, value: 0.00607}
+          - {label: add, value: 0.04297}
+        value: 0.04245
+      - errors:
+          - {label: unc, value: 0.00499}
+          - {label: add, value: 0.05445}
+        value: 0.03306
+      - errors:
+          - {label: unc, value: 0.00292}
+          - {label: add, value: 0.04409}
+        value: 0.02722
+      - errors:
+          - {label: unc, value: 0.01401}
+          - {label: add, value: 0.04158}
+        value: 0.12949
+      - errors:
+          - {label: unc, value: 0.0099}
+          - {label: add, value: 0.04208}
+        value: 0.10457
+      - errors:
+          - {label: unc, value: 0.00769}
+          - {label: add, value: 0.04322}
+        value: 0.07033
+      - errors:
+          - {label: unc, value: 0.00707}
+          - {label: add, value: 0.04253}
+        value: 0.06038
+      - errors:
+          - {label: unc, value: 0.00634}
+          - {label: add, value: 0.04364}
+        value: 0.05114
+      - errors:
+          - {label: unc, value: 0.00502}
+          - {label: add, value: 0.04401}
+        value: 0.03254
+      - errors:
+          - {label: unc, value: 0.00384}
+          - {label: add, value: 0.04408}
+        value: 0.03612
+      - errors:
+          - {label: unc, value: 0.02696}
+          - {label: add, value: 0.04166}
+        value: 0.2863
+      - errors:
+          - {label: unc, value: 0.01667}
+          - {label: add, value: 0.04138}
+        value: 0.23197
+      - errors:
+          - {label: unc, value: 0.01111}
+          - {label: add, value: 0.04131}
+        value: 0.14542
+      - errors:
+          - {label: unc, value: 0.00992}
+          - {label: add, value: 0.04181}
+        value: 0.12112
+      - errors:
+          - {label: unc, value: 0.00909}
+          - {label: add, value: 0.04173}
+        value: 0.10257
+      - errors:
+          - {label: unc, value: 0.00744}
+          - {label: add, value: 0.04188}
+        value: 0.0764
+      - errors:
+          - {label: unc, value: 0.00694}
+          - {label: add, value: 0.04363}
+        value: 0.06509
+      - errors:
+          - {label: unc, value: 0.00653}
+          - {label: add, value: 0.0492}
+        value: 0.05431
+      - errors:
+          - {label: unc, value: 0.00541}
+          - {label: add, value: 0.0468}
+        value: 0.04171
+      - errors:
+          - {label: unc, value: 0.00319}
+          - {label: add, value: 0.05524}
+        value: 0.0252
+      - errors:
+          - {label: unc, value: 0.04356}
+          - {label: add, value: 0.04171}
+        value: 0.46353
+      - errors:
+          - {label: unc, value: 0.02573}
+          - {label: add, value: 0.04156}
+        value: 0.35442
+      - errors:
+          - {label: unc, value: 0.02295}
+          - {label: add, value: 0.0419}
+        value: 0.30283
+      - errors:
+          - {label: unc, value: 0.02136}
+          - {label: add, value: 0.04245}
+        value: 0.26726
+      - errors:
+          - {label: unc, value: 0.01634}
+          - {label: add, value: 0.04243}
+        value: 0.17348
+      - errors:
+          - {label: unc, value: 0.01528}
+          - {label: add, value: 0.04579}
+        value: 0.14921
+      - errors:
+          - {label: unc, value: 0.0146}
+          - {label: add, value: 0.05183}
+        value: 0.12502
+      - errors:
+          - {label: unc, value: 0.01304}
+          - {label: add, value: 0.05571}
+        value: 0.08659
+      - errors:
+          - {label: unc, value: 0.01295}
+          - {label: add, value: 0.07888}
+        value: 0.07028
+      - errors:
+          - {label: unc, value: 0.01456}
+          - {label: add, value: 0.03577}
+        value: 0.07538
+      - errors:
+          - {label: unc, value: 0.01581}
+          - {label: add, value: 0.09776}
+        value: 0.05319
+      - errors:
+          - {label: unc, value: 0.07316}
+          - {label: add, value: 0.04197}
+        value: 0.56747
+      - errors:
+          - {label: unc, value: 0.05465}
+          - {label: add, value: 0.04761}
+        value: 0.29574
+      - errors:
+          - {label: unc, value: 0.05286}
+          - {label: add, value: 0.04607}
+        value: 0.29992
+      - errors:
+          - {label: unc, value: 0.06065}
+          - {label: add, value: 0.05078}
+        value: 0.30895
+      - errors:
+          - {label: unc, value: 0.06273}
+          - {label: add, value: 0.04667}
+        value: 0.1918
+      - errors:
+          - {label: unc, value: 0.01567}
+          - {label: add, value: 0.04633}
+        value: 0.06889
+      - errors:
+          - {label: unc, value: 0.01243}
+          - {label: add, value: 0.03758}
+        value: 0.06451
+      - errors:
+          - {label: unc, value: 0.00725}
+          - {label: add, value: 0.07778}
+        value: 0.0288
+      - errors:
+          - {label: unc, value: 0.00479}
+          - {label: add, value: 0.04397}
+        value: 0.02729
+      - errors:
+          - {label: unc, value: 0.02165}
+          - {label: add, value: 0.04149}
+        value: 0.12977
+      - errors:
+          - {label: unc, value: 0.01382}
+          - {label: add, value: 0.04156}
+        value: 0.09201
+      - errors:
+          - {label: unc, value: 0.00837}
+          - {label: add, value: 0.05352}
+        value: 0.04096
+      - errors:
+          - {label: unc, value: 0.01484}
+          - {label: add, value: 0.04416}
+        value: 0.09402
+      - errors:
+          - {label: unc, value: 0.01115}
+          - {label: add, value: 0.04393}
+        value: 0.06301
+      - errors:
+          - {label: unc, value: 0.01072}
+          - {label: add, value: 0.03852}
+        value: 0.04985
+      - errors:
+          - {label: unc, value: 0.00408}
+          - {label: add, value: 0.04313}
+        value: 0.02022
+      - errors:
+          - {label: unc, value: 0.03343}
+          - {label: add, value: 0.04121}
+        value: 0.21684
+      - errors:
+          - {label: unc, value: 0.02255}
+          - {label: add, value: 0.04518}
+        value: 0.19709
+      - errors:
+          - {label: unc, value: 0.01616}
+          - {label: add, value: 0.04213}
+        value: 0.14755
+      - errors:
+          - {label: unc, value: 0.01736}
+          - {label: add, value: 0.04173}
+        value: 0.15412
+      - errors:
+          - {label: unc, value: 0.01388}
+          - {label: add, value: 0.04253}
+        value: 0.1106
+      - errors:
+          - {label: unc, value: 0.01301}
+          - {label: add, value: 0.04244}
+        value: 0.10067
+      - errors:
+          - {label: unc, value: 0.01006}
+          - {label: add, value: 0.04838}
+        value: 0.06515
+      - errors:
+          - {label: unc, value: 0.0076}
+          - {label: add, value: 0.04362}
+        value: 0.0387
+      - errors:
+          - {label: unc, value: 0.00917}
+          - {label: add, value: 0.04957}
+        value: 0.04713
+      - errors:
+          - {label: unc, value: 0.00498}
+          - {label: add, value: 0.04105}
+        value: 0.02787
+      - errors:
+          - {label: unc, value: 0.07816}
+          - {label: add, value: 0.04194}
+        value: 0.55603
+      - errors:
+          - {label: unc, value: 0.03927}
+          - {label: add, value: 0.04271}
+        value: 0.36374
+      - errors:
+          - {label: unc, value: 0.03001}
+          - {label: add, value: 0.04393}
+        value: 0.24711
+      - errors:
+          - {label: unc, value: 0.0276}
+          - {label: add, value: 0.04527}
+        value: 0.20889
+      - errors:
+          - {label: unc, value: 0.02411}
+          - {label: add, value: 0.04425}
+        value: 0.16053
+      - errors:
+          - {label: unc, value: 0.0231}
+          - {label: add, value: 0.0516}
+        value: 0.14372
+      - errors:
+          - {label: unc, value: 0.02578}
+          - {label: add, value: 0.04882}
+        value: 0.14831
+      - errors:
+          - {label: unc, value: 0.02259}
+          - {label: add, value: 0.05727}
+        value: 0.11329
+      - errors:
+          - {label: unc, value: 0.02312}
+          - {label: add, value: 0.07152}
+        value: 0.09419
+      - errors:
+          - {label: unc, value: 0.07464}
+          - {label: add, value: 0.04354}
+        value: 0.27155
+      - errors:
+          - {label: unc, value: 0.10292}
+          - {label: add, value: 0.04374}
+        value: 0.4435
+      - errors:
+          - {label: unc, value: 0.07864}
+          - {label: add, value: 0.04782}
+        value: 0.25396
+      - errors:
+          - {label: unc, value: 0.07799}
+          - {label: add, value: 0.03564}
+        value: 0.24151
+      - errors:
+          - {label: unc, value: 0.02681}
+          - {label: add, value: 0.04605}
+        value: 0.15583
+      - errors:
+          - {label: unc, value: 0.01716}
+          - {label: add, value: 0.04135}
+        value: 0.10816
+      - errors:
+          - {label: unc, value: 0.00932}
+          - {label: add, value: 0.07841}
+        value: 0.03775
+      - errors:
+          - {label: unc, value: 0.01361}
+          - {label: add, value: 0.04222}
+        value: 0.07182
+      - errors:
+          - {label: unc, value: 0.01293}
+          - {label: add, value: 0.03825}
+        value: 0.06567
+      - errors:
+          - {label: unc, value: 0.0114}
+          - {label: add, value: 0.04349}
+        value: 0.05114
+      - errors:
+          - {label: unc, value: 0.00597}
+          - {label: add, value: 0.04426}
+        value: 0.0291
+      - errors:
+          - {label: unc, value: 0.03571}
+          - {label: add, value: 0.04163}
+        value: 0.22945
+      - errors:
+          - {label: unc, value: 0.02375}
+          - {label: add, value: 0.0417}
+        value: 0.21871
+      - errors:
+          - {label: unc, value: 0.01745}
+          - {label: add, value: 0.04268}
+        value: 0.14977
+      - errors:
+          - {label: unc, value: 0.01696}
+          - {label: add, value: 0.04307}
+        value: 0.14394
+      - errors:
+          - {label: unc, value: 0.0142}
+          - {label: add, value: 0.04142}
+        value: 0.10314
+      - errors:
+          - {label: unc, value: 0.01422}
+          - {label: add, value: 0.04195}
+        value: 0.10221
+      - errors:
+          - {label: unc, value: 0.01112}
+          - {label: add, value: 0.04687}
+        value: 0.07151
+      - errors:
+          - {label: unc, value: 0.00953}
+          - {label: add, value: 0.0503}
+        value: 0.05121
+      - errors:
+          - {label: unc, value: 0.00893}
+          - {label: add, value: 0.0563}
+        value: 0.0476
+      - errors:
+          - {label: unc, value: 0.00469}
+          - {label: add, value: 0.06312}
+        value: 0.02497
+      - errors:
+          - {label: unc, value: 0.0701}
+          - {label: add, value: 0.04251}
+        value: 0.51602
+      - errors:
+          - {label: unc, value: 0.03871}
+          - {label: add, value: 0.04287}
+        value: 0.3721
+      - errors:
+          - {label: unc, value: 0.03248}
+          - {label: add, value: 0.04259}
+        value: 0.27725
+      - errors:
+          - {label: unc, value: 0.02997}
+          - {label: add, value: 0.0419}
+        value: 0.24251
+      - errors:
+          - {label: unc, value: 0.02359}
+          - {label: add, value: 0.04288}
+        value: 0.16829
+      - errors:
+          - {label: unc, value: 0.02467}
+          - {label: add, value: 0.04534}
+        value: 0.16144
+      - errors:
+          - {label: unc, value: 0.02093}
+          - {label: add, value: 0.0464}
+        value: 0.11414
+      - errors:
+          - {label: unc, value: 0.02094}
+          - {label: add, value: 0.0635}
+        value: 0.10318
+      - errors:
+          - {label: unc, value: 0.02871}
+          - {label: add, value: 0.06687}
+        value: 0.12024
+      - errors:
+          - {label: unc, value: 0.02693}
+          - {label: add, value: 0.01845}
+        value: 0.05203
+      - errors:
+          - {label: unc, value: 0.17557}
+          - {label: add, value: 0.04223}
+        value: 0.60178
+      - errors:
+          - {label: unc, value: 0.12125}
+          - {label: add, value: 0.06181}
+        value: 0.34533
+      - errors:
+          - {label: unc, value: 0.08225}
+          - {label: add, value: 0.05835}
+        value: 0.17084
+independent_variables:
+  - header: {name: z}
+    values:
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+  - header: {name: x}
+    values:
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+  - header: {name: y}
+    values:
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+  - header: {name: Q2}
+    values:
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 28.89816}
+      - {value: 28.89816}
+      - {value: 28.89816}
+      - {value: 28.89816}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 52.377915}
+      - {value: 52.377915}
+      - {value: 52.377915}

--- a/data/COMPASS_KA_PLUS_2026.yaml
+++ b/data/COMPASS_KA_PLUS_2026.yaml
@@ -1,0 +1,2464 @@
+dependent_variables:
+  - header: {title: COMPASS $K^+$ Multiplicities}
+    qualifiers:
+      - {name: process, value: SIDIS}
+      - {name: observable, value: dsigma/dxdydz}
+      - {name: target_isoscalarity, value: 0.5}
+      - {name: prefactor, value: 1}
+      - {name: Vs, value: 17.35}
+      - {name: Q, low: 0.9, high: 6.0, integrate: true}
+      - {name: x, low: 0.004, high: 0.4, integrate: true}
+      - {name: z, low: 0.2, high: 0.85, integrate: true}
+      - {name: PS_reduction, W: 5, ymin: 0.1, ymax: 0.7}
+      - {name: hadron, value: KA}
+      - {name: charge, value: 1}
+    values:
+      - errors:
+          - {label: unc, value: 0.01852}
+          - {label: add, value: 0.05817}
+        value: 0.3851
+      - errors:
+          - {label: unc, value: 0.01454}
+          - {label: add, value: 0.05773}
+        value: 0.2993
+      - errors:
+          - {label: unc, value: 0.01163}
+          - {label: add, value: 0.05761}
+        value: 0.2319
+      - errors:
+          - {label: unc, value: 0.00918}
+          - {label: add, value: 0.05656}
+        value: 0.1768
+      - errors:
+          - {label: unc, value: 0.00737}
+          - {label: add, value: 0.05757}
+        value: 0.1334
+      - errors:
+          - {label: unc, value: 0.0062}
+          - {label: add, value: 0.05967}
+        value: 0.1019
+      - errors:
+          - {label: unc, value: 0.00646}
+          - {label: add, value: 0.072}
+        value: 0.08
+      - errors:
+          - {label: unc, value: 0.00648}
+          - {label: add, value: 0.07729}
+        value: 0.059
+      - errors:
+          - {label: unc, value: 0.00993}
+          - {label: add, value: 0.08028}
+        value: 0.0578
+      - errors:
+          - {label: unc, value: 0.01731}
+          - {label: add, value: 0.11368}
+        value: 0.038
+      - errors:
+          - {label: unc, value: 0.01958}
+          - {label: add, value: 0.06389}
+        value: 0.3957
+      - errors:
+          - {label: unc, value: 0.0152}
+          - {label: add, value: 0.06337}
+        value: 0.3055
+      - errors:
+          - {label: unc, value: 0.01138}
+          - {label: add, value: 0.0633}
+        value: 0.2237
+      - errors:
+          - {label: unc, value: 0.00911}
+          - {label: add, value: 0.06267}
+        value: 0.1685
+      - errors:
+          - {label: unc, value: 0.00805}
+          - {label: add, value: 0.06108}
+        value: 0.1218
+      - errors:
+          - {label: unc, value: 0.01309}
+          - {label: add, value: 0.05273}
+        value: 0.132
+      - errors:
+          - {label: unc, value: 0.00915}
+          - {label: add, value: 0.05216}
+        value: 0.1089
+      - errors:
+          - {label: unc, value: 0.00881}
+          - {label: add, value: 0.05372}
+        value: 0.0968
+      - errors:
+          - {label: unc, value: 0.00614}
+          - {label: add, value: 0.05563}
+        value: 0.0604
+      - errors:
+          - {label: unc, value: 0.00568}
+          - {label: add, value: 0.05261}
+        value: 0.0517
+      - errors:
+          - {label: unc, value: 0.00469}
+          - {label: add, value: 0.04875}
+        value: 0.0361
+      - errors:
+          - {label: unc, value: 0.00516}
+          - {label: add, value: 0.04841}
+        value: 0.0347
+      - errors:
+          - {label: unc, value: 0.00294}
+          - {label: add, value: 0.048}
+        value: 0.025
+      - errors:
+          - {label: unc, value: 0.01106}
+          - {label: add, value: 0.05293}
+        value: 0.2388
+      - errors:
+          - {label: unc, value: 0.00819}
+          - {label: add, value: 0.05181}
+        value: 0.1853
+      - errors:
+          - {label: unc, value: 0.00648}
+          - {label: add, value: 0.05326}
+        value: 0.1412
+      - errors:
+          - {label: unc, value: 0.00504}
+          - {label: add, value: 0.05289}
+        value: 0.1074
+      - errors:
+          - {label: unc, value: 0.00423}
+          - {label: add, value: 0.05427}
+        value: 0.0855
+      - errors:
+          - {label: unc, value: 0.00356}
+          - {label: add, value: 0.05926}
+        value: 0.0648
+      - errors:
+          - {label: unc, value: 0.00283}
+          - {label: add, value: 0.05234}
+        value: 0.0535
+      - errors:
+          - {label: unc, value: 0.00223}
+          - {label: add, value: 0.05093}
+        value: 0.0377
+      - errors:
+          - {label: unc, value: 0.00207}
+          - {label: add, value: 0.05449}
+        value: 0.0323
+      - errors:
+          - {label: unc, value: 0.00154}
+          - {label: add, value: 0.06316}
+        value: 0.0228
+      - errors:
+          - {label: unc, value: 0.01767}
+          - {label: add, value: 0.05742}
+        value: 0.3929
+      - errors:
+          - {label: unc, value: 0.01311}
+          - {label: add, value: 0.05586}
+        value: 0.3022
+      - errors:
+          - {label: unc, value: 0.0106}
+          - {label: add, value: 0.05555}
+        value: 0.2434
+      - errors:
+          - {label: unc, value: 0.00831}
+          - {label: add, value: 0.0551}
+        value: 0.1902
+      - errors:
+          - {label: unc, value: 0.00631}
+          - {label: add, value: 0.05576}
+        value: 0.1406
+      - errors:
+          - {label: unc, value: 0.00528}
+          - {label: add, value: 0.05541}
+        value: 0.1155
+      - errors:
+          - {label: unc, value: 0.00427}
+          - {label: add, value: 0.05856}
+        value: 0.0847
+      - errors:
+          - {label: unc, value: 0.00386}
+          - {label: add, value: 0.06325}
+        value: 0.0683
+      - errors:
+          - {label: unc, value: 0.00323}
+          - {label: add, value: 0.06534}
+        value: 0.0502
+      - errors:
+          - {label: unc, value: 0.00359}
+          - {label: add, value: 0.07783}
+        value: 0.0442
+      - errors:
+          - {label: unc, value: 0.00369}
+          - {label: add, value: 0.1}
+        value: 0.0304
+      - errors:
+          - {label: unc, value: 0.02011}
+          - {label: add, value: 0.06365}
+        value: 0.4085
+      - errors:
+          - {label: unc, value: 0.0156}
+          - {label: add, value: 0.06336}
+        value: 0.3144
+      - errors:
+          - {label: unc, value: 0.01189}
+          - {label: add, value: 0.06281}
+        value: 0.2369
+      - errors:
+          - {label: unc, value: 0.0098}
+          - {label: add, value: 0.06229}
+        value: 0.1875
+      - errors:
+          - {label: unc, value: 0.0089}
+          - {label: add, value: 0.06639}
+        value: 0.1422
+      - errors:
+          - {label: unc, value: 0.00543}
+          - {label: add, value: 0.05209}
+        value: 0.0599
+      - errors:
+          - {label: unc, value: 0.00431}
+          - {label: add, value: 0.04797}
+        value: 0.0567
+      - errors:
+          - {label: unc, value: 0.00368}
+          - {label: add, value: 0.04586}
+        value: 0.0471
+      - errors:
+          - {label: unc, value: 0.00307}
+          - {label: add, value: 0.04553}
+        value: 0.0369
+      - errors:
+          - {label: unc, value: 0.00204}
+          - {label: add, value: 0.04706}
+        value: 0.0272
+      - errors:
+          - {label: unc, value: 0.0105}
+          - {label: add, value: 0.04987}
+        value: 0.1492
+      - errors:
+          - {label: unc, value: 0.00594}
+          - {label: add, value: 0.05009}
+        value: 0.1118
+      - errors:
+          - {label: unc, value: 0.00455}
+          - {label: add, value: 0.05141}
+        value: 0.0887
+      - errors:
+          - {label: unc, value: 0.00384}
+          - {label: add, value: 0.05387}
+        value: 0.0698
+      - errors:
+          - {label: unc, value: 0.00319}
+          - {label: add, value: 0.04844}
+        value: 0.0578
+      - errors:
+          - {label: unc, value: 0.00258}
+          - {label: add, value: 0.04651}
+        value: 0.043
+      - errors:
+          - {label: unc, value: 0.0024}
+          - {label: add, value: 0.04693}
+        value: 0.0375
+      - errors:
+          - {label: unc, value: 0.00138}
+          - {label: add, value: 0.0487}
+        value: 0.023
+      - errors:
+          - {label: unc, value: 0.01146}
+          - {label: add, value: 0.05157}
+        value: 0.2327
+      - errors:
+          - {label: unc, value: 0.00885}
+          - {label: add, value: 0.05048}
+        value: 0.1981
+      - errors:
+          - {label: unc, value: 0.00669}
+          - {label: add, value: 0.05013}
+        value: 0.15
+      - errors:
+          - {label: unc, value: 0.00537}
+          - {label: add, value: 0.04996}
+        value: 0.1169
+      - errors:
+          - {label: unc, value: 0.00451}
+          - {label: add, value: 0.05037}
+        value: 0.0937
+      - errors:
+          - {label: unc, value: 0.0037}
+          - {label: add, value: 0.05266}
+        value: 0.0714
+      - errors:
+          - {label: unc, value: 0.00293}
+          - {label: add, value: 0.04945}
+        value: 0.055
+      - errors:
+          - {label: unc, value: 0.00257}
+          - {label: add, value: 0.04943}
+        value: 0.0437
+      - errors:
+          - {label: unc, value: 0.0022}
+          - {label: add, value: 0.0506}
+        value: 0.0332
+      - errors:
+          - {label: unc, value: 0.00157}
+          - {label: add, value: 0.05714}
+        value: 0.0238
+      - errors:
+          - {label: unc, value: 0.01862}
+          - {label: add, value: 0.05617}
+        value: 0.4045
+      - errors:
+          - {label: unc, value: 0.01449}
+          - {label: add, value: 0.0547}
+        value: 0.3305
+      - errors:
+          - {label: unc, value: 0.01107}
+          - {label: add, value: 0.05438}
+        value: 0.2501
+      - errors:
+          - {label: unc, value: 0.00873}
+          - {label: add, value: 0.05372}
+        value: 0.1951
+      - errors:
+          - {label: unc, value: 0.00741}
+          - {label: add, value: 0.05356}
+        value: 0.1613
+      - errors:
+          - {label: unc, value: 0.00587}
+          - {label: add, value: 0.05373}
+        value: 0.1221
+      - errors:
+          - {label: unc, value: 0.00467}
+          - {label: add, value: 0.05571}
+        value: 0.0876
+      - errors:
+          - {label: unc, value: 0.00435}
+          - {label: add, value: 0.05992}
+        value: 0.0721
+      - errors:
+          - {label: unc, value: 0.00419}
+          - {label: add, value: 0.06596}
+        value: 0.057
+      - errors:
+          - {label: unc, value: 0.00394}
+          - {label: add, value: 0.06776}
+        value: 0.0425
+      - errors:
+          - {label: unc, value: 0.00542}
+          - {label: add, value: 0.07332}
+        value: 0.0491
+      - errors:
+          - {label: unc, value: 0.02103}
+          - {label: add, value: 0.06213}
+        value: 0.4146
+      - errors:
+          - {label: unc, value: 0.01741}
+          - {label: add, value: 0.0619}
+        value: 0.3373
+      - errors:
+          - {label: unc, value: 0.01327}
+          - {label: add, value: 0.06159}
+        value: 0.2455
+      - errors:
+          - {label: unc, value: 0.01176}
+          - {label: add, value: 0.06108}
+        value: 0.203
+      - errors:
+          - {label: unc, value: 0.01229}
+          - {label: add, value: 0.06525}
+        value: 0.1643
+      - errors:
+          - {label: unc, value: 0.00667}
+          - {label: add, value: 0.04813}
+        value: 0.0748
+      - errors:
+          - {label: unc, value: 0.00411}
+          - {label: add, value: 0.04689}
+        value: 0.0563
+      - errors:
+          - {label: unc, value: 0.00289}
+          - {label: add, value: 0.04444}
+        value: 0.0432
+      - errors:
+          - {label: unc, value: 0.00245}
+          - {label: add, value: 0.04578}
+        value: 0.0367
+      - errors:
+          - {label: unc, value: 0.00135}
+          - {label: add, value: 0.0437}
+        value: 0.0238
+      - errors:
+          - {label: unc, value: 0.01369}
+          - {label: add, value: 0.04812}
+        value: 0.1546
+      - errors:
+          - {label: unc, value: 0.00763}
+          - {label: add, value: 0.0477}
+        value: 0.1241
+      - errors:
+          - {label: unc, value: 0.00496}
+          - {label: add, value: 0.0475}
+        value: 0.0859
+      - errors:
+          - {label: unc, value: 0.0043}
+          - {label: add, value: 0.05021}
+        value: 0.0701
+      - errors:
+          - {label: unc, value: 0.00359}
+          - {label: add, value: 0.04623}
+        value: 0.0571
+      - errors:
+          - {label: unc, value: 0.00315}
+          - {label: add, value: 0.04665}
+        value: 0.0463
+      - errors:
+          - {label: unc, value: 0.00268}
+          - {label: add, value: 0.04665}
+        value: 0.0343
+      - errors:
+          - {label: unc, value: 0.00175}
+          - {label: add, value: 0.04494}
+        value: 0.0267
+      - errors:
+          - {label: unc, value: 0.01313}
+          - {label: add, value: 0.05051}
+        value: 0.255
+      - errors:
+          - {label: unc, value: 0.00928}
+          - {label: add, value: 0.04939}
+        value: 0.1976
+      - errors:
+          - {label: unc, value: 0.00701}
+          - {label: add, value: 0.04896}
+        value: 0.1487
+      - errors:
+          - {label: unc, value: 0.00627}
+          - {label: add, value: 0.04865}
+        value: 0.1299
+      - errors:
+          - {label: unc, value: 0.00487}
+          - {label: add, value: 0.04884}
+        value: 0.095
+      - errors:
+          - {label: unc, value: 0.00408}
+          - {label: add, value: 0.04986}
+        value: 0.0738
+      - errors:
+          - {label: unc, value: 0.00342}
+          - {label: add, value: 0.04828}
+        value: 0.058
+      - errors:
+          - {label: unc, value: 0.00305}
+          - {label: add, value: 0.04735}
+        value: 0.049
+      - errors:
+          - {label: unc, value: 0.00262}
+          - {label: add, value: 0.04773}
+        value: 0.0352
+      - errors:
+          - {label: unc, value: 0.00178}
+          - {label: add, value: 0.05059}
+        value: 0.0253
+      - errors:
+          - {label: unc, value: 0.02002}
+          - {label: add, value: 0.0555}
+        value: 0.418
+      - errors:
+          - {label: unc, value: 0.01519}
+          - {label: add, value: 0.05377}
+        value: 0.3392
+      - errors:
+          - {label: unc, value: 0.012}
+          - {label: add, value: 0.05331}
+        value: 0.2641
+      - errors:
+          - {label: unc, value: 0.00967}
+          - {label: add, value: 0.05308}
+        value: 0.208
+      - errors:
+          - {label: unc, value: 0.00778}
+          - {label: add, value: 0.05297}
+        value: 0.1616
+      - errors:
+          - {label: unc, value: 0.00623}
+          - {label: add, value: 0.05281}
+        value: 0.1227
+      - errors:
+          - {label: unc, value: 0.00552}
+          - {label: add, value: 0.05434}
+        value: 0.0957
+      - errors:
+          - {label: unc, value: 0.00558}
+          - {label: add, value: 0.05714}
+        value: 0.0882
+      - errors:
+          - {label: unc, value: 0.00509}
+          - {label: add, value: 0.05672}
+        value: 0.0677
+      - errors:
+          - {label: unc, value: 0.00526}
+          - {label: add, value: 0.07604}
+        value: 0.0505
+      - errors:
+          - {label: unc, value: 0.00697}
+          - {label: add, value: 0.10469}
+        value: 0.0512
+      - errors:
+          - {label: unc, value: 0.02238}
+          - {label: add, value: 0.06117}
+        value: 0.4172
+      - errors:
+          - {label: unc, value: 0.01923}
+          - {label: add, value: 0.06097}
+        value: 0.3464
+      - errors:
+          - {label: unc, value: 0.01573}
+          - {label: add, value: 0.06054}
+        value: 0.2656
+      - errors:
+          - {label: unc, value: 0.01353}
+          - {label: add, value: 0.05929}
+        value: 0.2051
+      - errors:
+          - {label: unc, value: 0.01473}
+          - {label: add, value: 0.06221}
+        value: 0.1736
+      - errors:
+          - {label: unc, value: 0.0066}
+          - {label: add, value: 0.04652}
+        value: 0.0791
+      - errors:
+          - {label: unc, value: 0.00399}
+          - {label: add, value: 0.04444}
+        value: 0.0576
+      - errors:
+          - {label: unc, value: 0.00303}
+          - {label: add, value: 0.04379}
+        value: 0.0475
+      - errors:
+          - {label: unc, value: 0.0026}
+          - {label: add, value: 0.04455}
+        value: 0.0413
+      - errors:
+          - {label: unc, value: 0.0015}
+          - {label: add, value: 0.0438}
+        value: 0.0274
+      - errors:
+          - {label: unc, value: 0.01164}
+          - {label: add, value: 0.04684}
+        value: 0.1486
+      - errors:
+          - {label: unc, value: 0.00684}
+          - {label: add, value: 0.04612}
+        value: 0.1249
+      - errors:
+          - {label: unc, value: 0.00511}
+          - {label: add, value: 0.04546}
+        value: 0.1003
+      - errors:
+          - {label: unc, value: 0.00419}
+          - {label: add, value: 0.04633}
+        value: 0.0777
+      - errors:
+          - {label: unc, value: 0.00343}
+          - {label: add, value: 0.04513}
+        value: 0.0585
+      - errors:
+          - {label: unc, value: 0.00286}
+          - {label: add, value: 0.04541}
+        value: 0.0458
+      - errors:
+          - {label: unc, value: 0.00265}
+          - {label: add, value: 0.04422}
+        value: 0.0398
+      - errors:
+          - {label: unc, value: 0.00155}
+          - {label: add, value: 0.04516}
+        value: 0.0248
+      - errors:
+          - {label: unc, value: 0.01273}
+          - {label: add, value: 0.04957}
+        value: 0.2663
+      - errors:
+          - {label: unc, value: 0.00891}
+          - {label: add, value: 0.04872}
+        value: 0.2036
+      - errors:
+          - {label: unc, value: 0.00685}
+          - {label: add, value: 0.04813}
+        value: 0.1579
+      - errors:
+          - {label: unc, value: 0.0058}
+          - {label: add, value: 0.04816}
+        value: 0.1279
+      - errors:
+          - {label: unc, value: 0.0048}
+          - {label: add, value: 0.04822}
+        value: 0.1012
+      - errors:
+          - {label: unc, value: 0.00406}
+          - {label: add, value: 0.04828}
+        value: 0.0812
+      - errors:
+          - {label: unc, value: 0.00311}
+          - {label: add, value: 0.04698}
+        value: 0.0596
+      - errors:
+          - {label: unc, value: 0.00254}
+          - {label: add, value: 0.04804}
+        value: 0.0433
+      - errors:
+          - {label: unc, value: 0.0024}
+          - {label: add, value: 0.04731}
+        value: 0.0372
+      - errors:
+          - {label: unc, value: 0.0015}
+          - {label: add, value: 0.05231}
+        value: 0.026
+      - errors:
+          - {label: unc, value: 0.01963}
+          - {label: add, value: 0.05448}
+        value: 0.4244
+      - errors:
+          - {label: unc, value: 0.01488}
+          - {label: add, value: 0.05271}
+        value: 0.3445
+      - errors:
+          - {label: unc, value: 0.01204}
+          - {label: add, value: 0.05256}
+        value: 0.2755
+      - errors:
+          - {label: unc, value: 0.00948}
+          - {label: add, value: 0.05223}
+        value: 0.2129
+      - errors:
+          - {label: unc, value: 0.00782}
+          - {label: add, value: 0.0517}
+        value: 0.1702
+      - errors:
+          - {label: unc, value: 0.0062}
+          - {label: add, value: 0.05216}
+        value: 0.1273
+      - errors:
+          - {label: unc, value: 0.00515}
+          - {label: add, value: 0.0525}
+        value: 0.096
+      - errors:
+          - {label: unc, value: 0.00474}
+          - {label: add, value: 0.05774}
+        value: 0.0762
+      - errors:
+          - {label: unc, value: 0.00523}
+          - {label: add, value: 0.06715}
+        value: 0.0691
+      - errors:
+          - {label: unc, value: 0.00456}
+          - {label: add, value: 0.06537}
+        value: 0.0514
+      - errors:
+          - {label: unc, value: 0.00548}
+          - {label: add, value: 0.08545}
+        value: 0.044
+      - errors:
+          - {label: unc, value: 0.02322}
+          - {label: add, value: 0.05963}
+        value: 0.436
+      - errors:
+          - {label: unc, value: 0.01945}
+          - {label: add, value: 0.05928}
+        value: 0.3495
+      - errors:
+          - {label: unc, value: 0.01539}
+          - {label: add, value: 0.05874}
+        value: 0.2615
+      - errors:
+          - {label: unc, value: 0.01348}
+          - {label: add, value: 0.05778}
+        value: 0.198
+      - errors:
+          - {label: unc, value: 0.01431}
+          - {label: add, value: 0.05991}
+        value: 0.1549
+      - errors:
+          - {label: unc, value: 0.00608}
+          - {label: add, value: 0.0445}
+        value: 0.0773
+      - errors:
+          - {label: unc, value: 0.0039}
+          - {label: add, value: 0.04274}
+        value: 0.0599
+      - errors:
+          - {label: unc, value: 0.00292}
+          - {label: add, value: 0.04246}
+        value: 0.0471
+      - errors:
+          - {label: unc, value: 0.00245}
+          - {label: add, value: 0.04221}
+        value: 0.0398
+      - errors:
+          - {label: unc, value: 0.0015}
+          - {label: add, value: 0.0427}
+        value: 0.0281
+      - errors:
+          - {label: unc, value: 0.01171}
+          - {label: add, value: 0.04539}
+        value: 0.1639
+      - errors:
+          - {label: unc, value: 0.00622}
+          - {label: add, value: 0.04452}
+        value: 0.1186
+      - errors:
+          - {label: unc, value: 0.00497}
+          - {label: add, value: 0.04423}
+        value: 0.1031
+      - errors:
+          - {label: unc, value: 0.004}
+          - {label: add, value: 0.04439}
+        value: 0.0793
+      - errors:
+          - {label: unc, value: 0.00319}
+          - {label: add, value: 0.04385}
+        value: 0.0602
+      - errors:
+          - {label: unc, value: 0.00278}
+          - {label: add, value: 0.04342}
+        value: 0.0479
+      - errors:
+          - {label: unc, value: 0.0023}
+          - {label: add, value: 0.04199}
+        value: 0.0362
+      - errors:
+          - {label: unc, value: 0.00146}
+          - {label: add, value: 0.04164}
+        value: 0.0269
+      - errors:
+          - {label: unc, value: 0.0126}
+          - {label: add, value: 0.04802}
+        value: 0.2749
+      - errors:
+          - {label: unc, value: 0.00906}
+          - {label: add, value: 0.04695}
+        value: 0.2164
+      - errors:
+          - {label: unc, value: 0.0069}
+          - {label: add, value: 0.04657}
+        value: 0.1649
+      - errors:
+          - {label: unc, value: 0.00563}
+          - {label: add, value: 0.04641}
+        value: 0.131
+      - errors:
+          - {label: unc, value: 0.00447}
+          - {label: add, value: 0.04608}
+        value: 0.1007
+      - errors:
+          - {label: unc, value: 0.00399}
+          - {label: add, value: 0.04569}
+        value: 0.0858
+      - errors:
+          - {label: unc, value: 0.00311}
+          - {label: add, value: 0.04553}
+        value: 0.0615
+      - errors:
+          - {label: unc, value: 0.00277}
+          - {label: add, value: 0.04563}
+        value: 0.0526
+      - errors:
+          - {label: unc, value: 0.0022}
+          - {label: add, value: 0.04628}
+        value: 0.0363
+      - errors:
+          - {label: unc, value: 0.0015}
+          - {label: add, value: 0.04982}
+        value: 0.0273
+      - errors:
+          - {label: unc, value: 0.0208}
+          - {label: add, value: 0.05284}
+        value: 0.4406
+      - errors:
+          - {label: unc, value: 0.01502}
+          - {label: add, value: 0.05098}
+        value: 0.3515
+      - errors:
+          - {label: unc, value: 0.0122}
+          - {label: add, value: 0.05041}
+        value: 0.2825
+      - errors:
+          - {label: unc, value: 0.00972}
+          - {label: add, value: 0.0503}
+        value: 0.2195
+      - errors:
+          - {label: unc, value: 0.00764}
+          - {label: add, value: 0.05021}
+        value: 0.1657
+      - errors:
+          - {label: unc, value: 0.00665}
+          - {label: add, value: 0.04982}
+        value: 0.1381
+      - errors:
+          - {label: unc, value: 0.00559}
+          - {label: add, value: 0.0501}
+        value: 0.1038
+      - errors:
+          - {label: unc, value: 0.00531}
+          - {label: add, value: 0.05511}
+        value: 0.0871
+      - errors:
+          - {label: unc, value: 0.00496}
+          - {label: add, value: 0.06454}
+        value: 0.0657
+      - errors:
+          - {label: unc, value: 0.0049}
+          - {label: add, value: 0.06269}
+        value: 0.0536
+      - errors:
+          - {label: unc, value: 0.00514}
+          - {label: add, value: 0.0933}
+        value: 0.0403
+      - errors:
+          - {label: unc, value: 0.02629}
+          - {label: add, value: 0.05775}
+        value: 0.4488
+      - errors:
+          - {label: unc, value: 0.02245}
+          - {label: add, value: 0.05757}
+        value: 0.3599
+      - errors:
+          - {label: unc, value: 0.01913}
+          - {label: add, value: 0.05708}
+        value: 0.2803
+      - errors:
+          - {label: unc, value: 0.0163}
+          - {label: add, value: 0.05608}
+        value: 0.1983
+      - errors:
+          - {label: unc, value: 0.01895}
+          - {label: add, value: 0.07051}
+        value: 0.1543
+      - errors:
+          - {label: unc, value: 0.00712}
+          - {label: add, value: 0.04249}
+        value: 0.0659
+      - errors:
+          - {label: unc, value: 0.00505}
+          - {label: add, value: 0.04147}
+        value: 0.0598
+      - errors:
+          - {label: unc, value: 0.0039}
+          - {label: add, value: 0.04098}
+        value: 0.0488
+      - errors:
+          - {label: unc, value: 0.00305}
+          - {label: add, value: 0.04113}
+        value: 0.0389
+      - errors:
+          - {label: unc, value: 0.00181}
+          - {label: add, value: 0.04088}
+        value: 0.0274
+      - errors:
+          - {label: unc, value: 0.01333}
+          - {label: add, value: 0.04329}
+        value: 0.1423
+      - errors:
+          - {label: unc, value: 0.00848}
+          - {label: add, value: 0.04318}
+        value: 0.1334
+      - errors:
+          - {label: unc, value: 0.00576}
+          - {label: add, value: 0.0424}
+        value: 0.1
+      - errors:
+          - {label: unc, value: 0.00479}
+          - {label: add, value: 0.04277}
+        value: 0.0823
+      - errors:
+          - {label: unc, value: 0.00399}
+          - {label: add, value: 0.04211}
+        value: 0.0608
+      - errors:
+          - {label: unc, value: 0.00368}
+          - {label: add, value: 0.04146}
+        value: 0.0521
+      - errors:
+          - {label: unc, value: 0.00272}
+          - {label: add, value: 0.04114}
+        value: 0.035
+      - errors:
+          - {label: unc, value: 0.00181}
+          - {label: add, value: 0.04308}
+        value: 0.026
+      - errors:
+          - {label: unc, value: 0.01518}
+          - {label: add, value: 0.04635}
+        value: 0.271
+      - errors:
+          - {label: unc, value: 0.00998}
+          - {label: add, value: 0.04511}
+        value: 0.2075
+      - errors:
+          - {label: unc, value: 0.00822}
+          - {label: add, value: 0.04462}
+        value: 0.1739
+      - errors:
+          - {label: unc, value: 0.00677}
+          - {label: add, value: 0.04409}
+        value: 0.1379
+      - errors:
+          - {label: unc, value: 0.0053}
+          - {label: add, value: 0.04422}
+        value: 0.0977
+      - errors:
+          - {label: unc, value: 0.00466}
+          - {label: add, value: 0.04385}
+        value: 0.0821
+      - errors:
+          - {label: unc, value: 0.004}
+          - {label: add, value: 0.04375}
+        value: 0.064
+      - errors:
+          - {label: unc, value: 0.00353}
+          - {label: add, value: 0.04366}
+        value: 0.0513
+      - errors:
+          - {label: unc, value: 0.00298}
+          - {label: add, value: 0.04421}
+        value: 0.038
+      - errors:
+          - {label: unc, value: 0.00201}
+          - {label: add, value: 0.05017}
+        value: 0.0287
+      - errors:
+          - {label: unc, value: 0.02501}
+          - {label: add, value: 0.04985}
+        value: 0.398
+      - errors:
+          - {label: unc, value: 0.01865}
+          - {label: add, value: 0.04839}
+        value: 0.3736
+      - errors:
+          - {label: unc, value: 0.01471}
+          - {label: add, value: 0.04787}
+        value: 0.2841
+      - errors:
+          - {label: unc, value: 0.01187}
+          - {label: add, value: 0.04768}
+        value: 0.2131
+      - errors:
+          - {label: unc, value: 0.01046}
+          - {label: add, value: 0.04752}
+        value: 0.1751
+      - errors:
+          - {label: unc, value: 0.00887}
+          - {label: add, value: 0.04748}
+        value: 0.1331
+      - errors:
+          - {label: unc, value: 0.00816}
+          - {label: add, value: 0.04741}
+        value: 0.108
+      - errors:
+          - {label: unc, value: 0.00788}
+          - {label: add, value: 0.04957}
+        value: 0.092
+      - errors:
+          - {label: unc, value: 0.00716}
+          - {label: add, value: 0.05193}
+        value: 0.0647
+      - errors:
+          - {label: unc, value: 0.00638}
+          - {label: add, value: 0.06154}
+        value: 0.0403
+      - errors:
+          - {label: unc, value: 0.00883}
+          - {label: add, value: 0.09238}
+        value: 0.0433
+      - errors:
+          - {label: unc, value: 0.03966}
+          - {label: add, value: 0.05435}
+        value: 0.4578
+      - errors:
+          - {label: unc, value: 0.03857}
+          - {label: add, value: 0.05412}
+        value: 0.3991
+      - errors:
+          - {label: unc, value: 0.02912}
+          - {label: add, value: 0.05756}
+        value: 0.2585
+      - errors:
+          - {label: unc, value: 0.03012}
+          - {label: add, value: 0.06922}
+        value: 0.1988
+      - errors:
+          - {label: unc, value: 0.02942}
+          - {label: add, value: 0.07796}
+        value: 0.1375
+      - errors:
+          - {label: unc, value: 0.01083}
+          - {label: add, value: 0.04083}
+        value: 0.0725
+      - errors:
+          - {label: unc, value: 0.00642}
+          - {label: add, value: 0.04022}
+        value: 0.0557
+      - errors:
+          - {label: unc, value: 0.00585}
+          - {label: add, value: 0.03986}
+        value: 0.0562
+      - errors:
+          - {label: unc, value: 0.00426}
+          - {label: add, value: 0.03918}
+        value: 0.0388
+      - errors:
+          - {label: unc, value: 0.00233}
+          - {label: add, value: 0.04094}
+        value: 0.0254
+      - errors:
+          - {label: unc, value: 0.02343}
+          - {label: add, value: 0.04239}
+        value: 0.1944
+      - errors:
+          - {label: unc, value: 0.01062}
+          - {label: add, value: 0.04227}
+        value: 0.1287
+      - errors:
+          - {label: unc, value: 0.00734}
+          - {label: add, value: 0.04115}
+        value: 0.0972
+      - errors:
+          - {label: unc, value: 0.00586}
+          - {label: add, value: 0.04119}
+        value: 0.0738
+      - errors:
+          - {label: unc, value: 0.00545}
+          - {label: add, value: 0.04122}
+        value: 0.0621
+      - errors:
+          - {label: unc, value: 0.00476}
+          - {label: add, value: 0.04168}
+        value: 0.0499
+      - errors:
+          - {label: unc, value: 0.00387}
+          - {label: add, value: 0.0399}
+        value: 0.0381
+      - errors:
+          - {label: unc, value: 0.00233}
+          - {label: add, value: 0.04177}
+        value: 0.0249
+      - errors:
+          - {label: unc, value: 0.01872}
+          - {label: add, value: 0.04476}
+        value: 0.2395
+      - errors:
+          - {label: unc, value: 0.0133}
+          - {label: add, value: 0.04367}
+        value: 0.2235
+      - errors:
+          - {label: unc, value: 0.00993}
+          - {label: add, value: 0.0431}
+        value: 0.1689
+      - errors:
+          - {label: unc, value: 0.00907}
+          - {label: add, value: 0.0432}
+        value: 0.1426
+      - errors:
+          - {label: unc, value: 0.00743}
+          - {label: add, value: 0.04322}
+        value: 0.1055
+      - errors:
+          - {label: unc, value: 0.00642}
+          - {label: add, value: 0.04309}
+        value: 0.0854
+      - errors:
+          - {label: unc, value: 0.0057}
+          - {label: add, value: 0.04274}
+        value: 0.073
+      - errors:
+          - {label: unc, value: 0.00469}
+          - {label: add, value: 0.04235}
+        value: 0.051
+      - errors:
+          - {label: unc, value: 0.00433}
+          - {label: add, value: 0.04434}
+        value: 0.0415
+      - errors:
+          - {label: unc, value: 0.00275}
+          - {label: add, value: 0.04196}
+        value: 0.0286
+      - errors:
+          - {label: unc, value: 0.03695}
+          - {label: add, value: 0.04775}
+        value: 0.4356
+      - errors:
+          - {label: unc, value: 0.02353}
+          - {label: add, value: 0.04658}
+        value: 0.3641
+      - errors:
+          - {label: unc, value: 0.01959}
+          - {label: add, value: 0.04652}
+        value: 0.2889
+      - errors:
+          - {label: unc, value: 0.01665}
+          - {label: add, value: 0.04583}
+        value: 0.2217
+      - errors:
+          - {label: unc, value: 0.01462}
+          - {label: add, value: 0.04617}
+        value: 0.175
+      - errors:
+          - {label: unc, value: 0.01191}
+          - {label: add, value: 0.04612}
+        value: 0.1249
+      - errors:
+          - {label: unc, value: 0.01243}
+          - {label: add, value: 0.04606}
+        value: 0.1129
+      - errors:
+          - {label: unc, value: 0.00962}
+          - {label: add, value: 0.05307}
+        value: 0.0618
+      - errors:
+          - {label: unc, value: 0.01158}
+          - {label: add, value: 0.06049}
+        value: 0.0648
+      - errors:
+          - {label: unc, value: 0.01433}
+          - {label: add, value: 0.05628}
+        value: 0.0725
+      - errors:
+          - {label: unc, value: 0.01579}
+          - {label: add, value: 0.05597}
+        value: 0.0586
+      - errors:
+          - {label: unc, value: 0.02}
+          - {label: add, value: 0.04104}
+        value: 0.1579
+      - errors:
+          - {label: unc, value: 0.01154}
+          - {label: add, value: 0.0409}
+        value: 0.133
+      - errors:
+          - {label: unc, value: 0.00939}
+          - {label: add, value: 0.04019}
+        value: 0.1254
+      - errors:
+          - {label: unc, value: 0.00732}
+          - {label: add, value: 0.03996}
+        value: 0.0901
+      - errors:
+          - {label: unc, value: 0.00537}
+          - {label: add, value: 0.03923}
+        value: 0.0571
+      - errors:
+          - {label: unc, value: 0.00558}
+          - {label: add, value: 0.04056}
+        value: 0.0572
+      - errors:
+          - {label: unc, value: 0.00426}
+          - {label: add, value: 0.03958}
+        value: 0.0384
+      - errors:
+          - {label: unc, value: 0.00241}
+          - {label: add, value: 0.0412}
+        value: 0.0233
+      - errors:
+          - {label: unc, value: 0.02103}
+          - {label: add, value: 0.04302}
+        value: 0.2659
+      - errors:
+          - {label: unc, value: 0.01346}
+          - {label: add, value: 0.04235}
+        value: 0.2097
+      - errors:
+          - {label: unc, value: 0.0112}
+          - {label: add, value: 0.04183}
+        value: 0.1836
+      - errors:
+          - {label: unc, value: 0.00866}
+          - {label: add, value: 0.04167}
+        value: 0.1267
+      - errors:
+          - {label: unc, value: 0.00725}
+          - {label: add, value: 0.04162}
+        value: 0.0961
+      - errors:
+          - {label: unc, value: 0.00656}
+          - {label: add, value: 0.04171}
+        value: 0.0844
+      - errors:
+          - {label: unc, value: 0.0061}
+          - {label: add, value: 0.04103}
+        value: 0.0702
+      - errors:
+          - {label: unc, value: 0.00495}
+          - {label: add, value: 0.04135}
+        value: 0.0503
+      - errors:
+          - {label: unc, value: 0.0045}
+          - {label: add, value: 0.04141}
+        value: 0.0425
+      - errors:
+          - {label: unc, value: 0.00273}
+          - {label: add, value: 0.04242}
+        value: 0.0264
+      - errors:
+          - {label: unc, value: 0.03866}
+          - {label: add, value: 0.04498}
+        value: 0.4251
+      - errors:
+          - {label: unc, value: 0.02393}
+          - {label: add, value: 0.04372}
+        value: 0.366
+      - errors:
+          - {label: unc, value: 0.01941}
+          - {label: add, value: 0.04358}
+        value: 0.2919
+      - errors:
+          - {label: unc, value: 0.01768}
+          - {label: add, value: 0.04332}
+        value: 0.2382
+      - errors:
+          - {label: unc, value: 0.01609}
+          - {label: add, value: 0.04317}
+        value: 0.202
+      - errors:
+          - {label: unc, value: 0.01203}
+          - {label: add, value: 0.04329}
+        value: 0.1275
+      - errors:
+          - {label: unc, value: 0.01099}
+          - {label: add, value: 0.04364}
+        value: 0.099
+      - errors:
+          - {label: unc, value: 0.01095}
+          - {label: add, value: 0.05079}
+        value: 0.0819
+      - errors:
+          - {label: unc, value: 0.01048}
+          - {label: add, value: 0.05614}
+        value: 0.057
+independent_variables:
+  - header: {name: z}
+    values:
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+  - header: {name: x}
+    values:
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+  - header: {name: y}
+    values:
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+  - header: {name: Q2}
+    values:
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}

--- a/data/COMPASS_PI_MINUS_2025.yaml
+++ b/data/COMPASS_PI_MINUS_2025.yaml
@@ -1,0 +1,2440 @@
+dependent_variables:
+  - header: {title: COMPASS $pi^-$ Multiplicities}
+    qualifiers:
+      - {name: process, value: SIDIS}
+      - {name: observable, value: dsigma/dxdydz}
+      - {name: target_isoscalarity, value: 1.0}
+      - {name: prefactor, value: 1}
+      - {name: Vs, value: 17.35}
+      - {name: Q, low: 0.9, high: 8.0, integrate: true}
+      - {name: x, low: 0.004, high: 0.4, integrate: true}
+      - {name: z, low: 0.2, high: 0.85, integrate: true}
+      - {name: PS_reduction, W: 5, ymin: 0.1, ymax: 0.7}
+      - {name: hadron, value: PI}
+      - {name: charge, value: -1}
+    values:
+      - errors:
+          - {label: unc, value: 0.07343}
+          - {label: add, value: 0.04645}
+        value: 2.0092
+      - errors:
+          - {label: unc, value: 0.05046}
+          - {label: add, value: 0.04656}
+        value: 1.35606
+      - errors:
+          - {label: unc, value: 0.03666}
+          - {label: add, value: 0.0471}
+        value: 0.95146
+      - errors:
+          - {label: unc, value: 0.02719}
+          - {label: add, value: 0.04751}
+        value: 0.6774
+      - errors:
+          - {label: unc, value: 0.02083}
+          - {label: add, value: 0.04863}
+        value: 0.49103
+      - errors:
+          - {label: unc, value: 0.01583}
+          - {label: add, value: 0.05038}
+        value: 0.34493
+      - errors:
+          - {label: unc, value: 0.01437}
+          - {label: add, value: 0.05391}
+        value: 0.26609
+      - errors:
+          - {label: unc, value: 0.01459}
+          - {label: add, value: 0.05839}
+        value: 0.2095
+      - errors:
+          - {label: unc, value: 0.07546}
+          - {label: add, value: 0.04969}
+        value: 1.97866
+      - errors:
+          - {label: unc, value: 0.05127}
+          - {label: add, value: 0.05007}
+        value: 1.31862
+      - errors:
+          - {label: unc, value: 0.03691}
+          - {label: add, value: 0.05036}
+        value: 0.92984
+      - errors:
+          - {label: unc, value: 0.02682}
+          - {label: add, value: 0.05029}
+        value: 0.64248
+      - errors:
+          - {label: unc, value: 0.02269}
+          - {label: add, value: 0.05104}
+        value: 0.46038
+      - errors:
+          - {label: unc, value: 0.03187}
+          - {label: add, value: 0.04681}
+        value: 0.50739
+      - errors:
+          - {label: unc, value: 0.02241}
+          - {label: add, value: 0.04817}
+        value: 0.39662
+      - errors:
+          - {label: unc, value: 0.01745}
+          - {label: add, value: 0.05301}
+        value: 0.27059
+      - errors:
+          - {label: unc, value: 0.0137}
+          - {label: add, value: 0.05813}
+        value: 0.18717
+      - errors:
+          - {label: unc, value: 0.01472}
+          - {label: add, value: 0.07195}
+        value: 0.18136
+      - errors:
+          - {label: unc, value: 0.01146}
+          - {label: add, value: 0.08782}
+        value: 0.1186
+      - errors:
+          - {label: unc, value: 0.00991}
+          - {label: add, value: 0.12086}
+        value: 0.08287
+      - errors:
+          - {label: unc, value: 0.00772}
+          - {label: add, value: 0.19254}
+        value: 0.04878
+      - errors:
+          - {label: unc, value: 0.03369}
+          - {label: add, value: 0.04422}
+        value: 0.94248
+      - errors:
+          - {label: unc, value: 0.02416}
+          - {label: add, value: 0.04492}
+        value: 0.67423
+      - errors:
+          - {label: unc, value: 0.01803}
+          - {label: add, value: 0.04584}
+        value: 0.48865
+      - errors:
+          - {label: unc, value: 0.01403}
+          - {label: add, value: 0.04743}
+        value: 0.36159
+      - errors:
+          - {label: unc, value: 0.01116}
+          - {label: add, value: 0.05071}
+        value: 0.26597
+      - errors:
+          - {label: unc, value: 0.00926}
+          - {label: add, value: 0.05586}
+        value: 0.19921
+      - errors:
+          - {label: unc, value: 0.00821}
+          - {label: add, value: 0.06495}
+        value: 0.15285
+      - errors:
+          - {label: unc, value: 0.00757}
+          - {label: add, value: 0.08502}
+        value: 0.11028
+      - errors:
+          - {label: unc, value: 0.00734}
+          - {label: add, value: 0.10801}
+        value: 0.08577
+      - errors:
+          - {label: unc, value: 0.0074}
+          - {label: add, value: 0.18576}
+        value: 0.05237
+      - errors:
+          - {label: unc, value: 0.06684}
+          - {label: add, value: 0.04424}
+        value: 1.96181
+      - errors:
+          - {label: unc, value: 0.0448}
+          - {label: add, value: 0.04438}
+        value: 1.3198
+      - errors:
+          - {label: unc, value: 0.03151}
+          - {label: add, value: 0.04467}
+        value: 0.91542
+      - errors:
+          - {label: unc, value: 0.0227}
+          - {label: add, value: 0.04511}
+        value: 0.64637
+      - errors:
+          - {label: unc, value: 0.01675}
+          - {label: add, value: 0.04582}
+        value: 0.46387
+      - errors:
+          - {label: unc, value: 0.01305}
+          - {label: add, value: 0.04697}
+        value: 0.34796
+      - errors:
+          - {label: unc, value: 0.01024}
+          - {label: add, value: 0.04975}
+        value: 0.25264
+      - errors:
+          - {label: unc, value: 0.00882}
+          - {label: add, value: 0.05403}
+        value: 0.19618
+      - errors:
+          - {label: unc, value: 0.00795}
+          - {label: add, value: 0.06218}
+        value: 0.1508
+      - errors:
+          - {label: unc, value: 0.00722}
+          - {label: add, value: 0.08132}
+        value: 0.10448
+      - errors:
+          - {label: unc, value: 0.0075}
+          - {label: add, value: 0.10788}
+        value: 0.08135
+      - errors:
+          - {label: unc, value: 0.06941}
+          - {label: add, value: 0.04607}
+        value: 1.94397
+      - errors:
+          - {label: unc, value: 0.04741}
+          - {label: add, value: 0.04637}
+        value: 1.29871
+      - errors:
+          - {label: unc, value: 0.03304}
+          - {label: add, value: 0.04662}
+        value: 0.88038
+      - errors:
+          - {label: unc, value: 0.02459}
+          - {label: add, value: 0.04683}
+        value: 0.6183
+      - errors:
+          - {label: unc, value: 0.02147}
+          - {label: add, value: 0.0471}
+        value: 0.46757
+      - errors:
+          - {label: unc, value: 0.01394}
+          - {label: add, value: 0.05625}
+        value: 0.21702
+      - errors:
+          - {label: unc, value: 0.01047}
+          - {label: add, value: 0.06267}
+        value: 0.16632
+      - errors:
+          - {label: unc, value: 0.00912}
+          - {label: add, value: 0.08074}
+        value: 0.12306
+      - errors:
+          - {label: unc, value: 0.00852}
+          - {label: add, value: 0.11822}
+        value: 0.08506
+      - errors:
+          - {label: unc, value: 0.00754}
+          - {label: add, value: 0.15637}
+        value: 0.06129
+      - errors:
+          - {label: unc, value: 0.0148}
+          - {label: add, value: 0.0461}
+        value: 0.35817
+      - errors:
+          - {label: unc, value: 0.01146}
+          - {label: add, value: 0.04896}
+        value: 0.27159
+      - errors:
+          - {label: unc, value: 0.00965}
+          - {label: add, value: 0.05328}
+        value: 0.21021
+      - errors:
+          - {label: unc, value: 0.00776}
+          - {label: add, value: 0.06088}
+        value: 0.14836
+      - errors:
+          - {label: unc, value: 0.00701}
+          - {label: add, value: 0.07588}
+        value: 0.10986
+      - errors:
+          - {label: unc, value: 0.00688}
+          - {label: add, value: 0.10513}
+        value: 0.08104
+      - errors:
+          - {label: unc, value: 0.00677}
+          - {label: add, value: 0.16032}
+        value: 0.05514
+      - errors:
+          - {label: unc, value: 0.03301}
+          - {label: add, value: 0.04304}
+        value: 0.89682
+      - errors:
+          - {label: unc, value: 0.02298}
+          - {label: add, value: 0.04339}
+        value: 0.6453
+      - errors:
+          - {label: unc, value: 0.01738}
+          - {label: add, value: 0.044}
+        value: 0.48113
+      - errors:
+          - {label: unc, value: 0.01326}
+          - {label: add, value: 0.0448}
+        value: 0.35178
+      - errors:
+          - {label: unc, value: 0.01005}
+          - {label: add, value: 0.0465}
+        value: 0.25047
+      - errors:
+          - {label: unc, value: 0.00842}
+          - {label: add, value: 0.04986}
+        value: 0.19317
+      - errors:
+          - {label: unc, value: 0.00693}
+          - {label: add, value: 0.05474}
+        value: 0.14352
+      - errors:
+          - {label: unc, value: 0.00587}
+          - {label: add, value: 0.0651}
+        value: 0.1036
+      - errors:
+          - {label: unc, value: 0.0054}
+          - {label: add, value: 0.08207}
+        value: 0.07769
+      - errors:
+          - {label: unc, value: 0.00544}
+          - {label: add, value: 0.13925}
+        value: 0.05044
+      - errors:
+          - {label: unc, value: 0.06663}
+          - {label: add, value: 0.04311}
+        value: 1.91624
+      - errors:
+          - {label: unc, value: 0.04347}
+          - {label: add, value: 0.04299}
+        value: 1.27675
+      - errors:
+          - {label: unc, value: 0.03122}
+          - {label: add, value: 0.04314}
+        value: 0.89794
+      - errors:
+          - {label: unc, value: 0.02223}
+          - {label: add, value: 0.04343}
+        value: 0.61757
+      - errors:
+          - {label: unc, value: 0.01663}
+          - {label: add, value: 0.04381}
+        value: 0.44358
+      - errors:
+          - {label: unc, value: 0.01246}
+          - {label: add, value: 0.04439}
+        value: 0.3152
+      - errors:
+          - {label: unc, value: 0.00974}
+          - {label: add, value: 0.04551}
+        value: 0.22481
+      - errors:
+          - {label: unc, value: 0.00838}
+          - {label: add, value: 0.04702}
+        value: 0.17407
+      - errors:
+          - {label: unc, value: 0.00772}
+          - {label: add, value: 0.04985}
+        value: 0.13994
+      - errors:
+          - {label: unc, value: 0.0074}
+          - {label: add, value: 0.05766}
+        value: 0.1096
+      - errors:
+          - {label: unc, value: 0.00629}
+          - {label: add, value: 0.07585}
+        value: 0.06497
+      - errors:
+          - {label: unc, value: 0.07223}
+          - {label: add, value: 0.045}
+        value: 1.94623
+      - errors:
+          - {label: unc, value: 0.04785}
+          - {label: add, value: 0.04531}
+        value: 1.22203
+      - errors:
+          - {label: unc, value: 0.0358}
+          - {label: add, value: 0.04557}
+        value: 0.86318
+      - errors:
+          - {label: unc, value: 0.02828}
+          - {label: add, value: 0.04558}
+        value: 0.60886
+      - errors:
+          - {label: unc, value: 0.02451}
+          - {label: add, value: 0.04589}
+        value: 0.39936
+      - errors:
+          - {label: unc, value: 0.0124}
+          - {label: add, value: 0.05126}
+        value: 0.18917
+      - errors:
+          - {label: unc, value: 0.00892}
+          - {label: add, value: 0.05825}
+        value: 0.1501
+      - errors:
+          - {label: unc, value: 0.00723}
+          - {label: add, value: 0.07037}
+        value: 0.11289
+      - errors:
+          - {label: unc, value: 0.0072}
+          - {label: add, value: 0.09299}
+        value: 0.09283
+      - errors:
+          - {label: unc, value: 0.00676}
+          - {label: add, value: 0.14635}
+        value: 0.06002
+      - errors:
+          - {label: unc, value: 0.01541}
+          - {label: add, value: 0.04457}
+        value: 0.33243
+      - errors:
+          - {label: unc, value: 0.0109}
+          - {label: add, value: 0.04558}
+        value: 0.2429
+      - errors:
+          - {label: unc, value: 0.00879}
+          - {label: add, value: 0.04863}
+        value: 0.18245
+      - errors:
+          - {label: unc, value: 0.00778}
+          - {label: add, value: 0.05268}
+        value: 0.14883
+      - errors:
+          - {label: unc, value: 0.00673}
+          - {label: add, value: 0.06309}
+        value: 0.11058
+      - errors:
+          - {label: unc, value: 0.00606}
+          - {label: add, value: 0.07175}
+        value: 0.08842
+      - errors:
+          - {label: unc, value: 0.00528}
+          - {label: add, value: 0.11535}
+        value: 0.0568
+      - errors:
+          - {label: unc, value: 0.03581}
+          - {label: add, value: 0.04247}
+        value: 0.88879
+      - errors:
+          - {label: unc, value: 0.0236}
+          - {label: add, value: 0.04302}
+        value: 0.61863
+      - errors:
+          - {label: unc, value: 0.01718}
+          - {label: add, value: 0.04319}
+        value: 0.44507
+      - errors:
+          - {label: unc, value: 0.01338}
+          - {label: add, value: 0.04375}
+        value: 0.32857
+      - errors:
+          - {label: unc, value: 0.01017}
+          - {label: add, value: 0.04468}
+        value: 0.23134
+      - errors:
+          - {label: unc, value: 0.00842}
+          - {label: add, value: 0.04653}
+        value: 0.17831
+      - errors:
+          - {label: unc, value: 0.00704}
+          - {label: add, value: 0.04934}
+        value: 0.13635
+      - errors:
+          - {label: unc, value: 0.00587}
+          - {label: add, value: 0.05453}
+        value: 0.10138
+      - errors:
+          - {label: unc, value: 0.00534}
+          - {label: add, value: 0.06721}
+        value: 0.07856
+      - errors:
+          - {label: unc, value: 0.00413}
+          - {label: add, value: 0.09927}
+        value: 0.04916
+      - errors:
+          - {label: unc, value: 0.07065}
+          - {label: add, value: 0.04288}
+        value: 1.91912
+      - errors:
+          - {label: unc, value: 0.04589}
+          - {label: add, value: 0.0428}
+        value: 1.29369
+      - errors:
+          - {label: unc, value: 0.03215}
+          - {label: add, value: 0.04295}
+        value: 0.87259
+      - errors:
+          - {label: unc, value: 0.02334}
+          - {label: add, value: 0.04324}
+        value: 0.60078
+      - errors:
+          - {label: unc, value: 0.01744}
+          - {label: add, value: 0.04355}
+        value: 0.42194
+      - errors:
+          - {label: unc, value: 0.01392}
+          - {label: add, value: 0.04398}
+        value: 0.31196
+      - errors:
+          - {label: unc, value: 0.01091}
+          - {label: add, value: 0.04459}
+        value: 0.21833
+      - errors:
+          - {label: unc, value: 0.00928}
+          - {label: add, value: 0.04531}
+        value: 0.15942
+      - errors:
+          - {label: unc, value: 0.00874}
+          - {label: add, value: 0.04749}
+        value: 0.12482
+      - errors:
+          - {label: unc, value: 0.00807}
+          - {label: add, value: 0.05119}
+        value: 0.09502
+      - errors:
+          - {label: unc, value: 0.00867}
+          - {label: add, value: 0.05454}
+        value: 0.07671
+      - errors:
+          - {label: unc, value: 0.08061}
+          - {label: add, value: 0.04437}
+        value: 1.99341
+      - errors:
+          - {label: unc, value: 0.05671}
+          - {label: add, value: 0.04445}
+        value: 1.28878
+      - errors:
+          - {label: unc, value: 0.04116}
+          - {label: add, value: 0.04475}
+        value: 0.84988
+      - errors:
+          - {label: unc, value: 0.03231}
+          - {label: add, value: 0.04495}
+        value: 0.55189
+      - errors:
+          - {label: unc, value: 0.03431}
+          - {label: add, value: 0.0466}
+        value: 0.4206
+      - errors:
+          - {label: unc, value: 0.00782}
+          - {label: add, value: 0.0496}
+        value: 0.13967
+      - errors:
+          - {label: unc, value: 0.00666}
+          - {label: add, value: 0.05687}
+        value: 0.11817
+      - errors:
+          - {label: unc, value: 0.00531}
+          - {label: add, value: 0.07121}
+        value: 0.08268
+      - errors:
+          - {label: unc, value: 0.00509}
+          - {label: add, value: 0.10636}
+        value: 0.0607
+      - errors:
+          - {label: unc, value: 0.01481}
+          - {label: add, value: 0.04313}
+        value: 0.32568
+      - errors:
+          - {label: unc, value: 0.01106}
+          - {label: add, value: 0.04399}
+        value: 0.25404
+      - errors:
+          - {label: unc, value: 0.00829}
+          - {label: add, value: 0.04592}
+        value: 0.17788
+      - errors:
+          - {label: unc, value: 0.00722}
+          - {label: add, value: 0.04718}
+        value: 0.1455
+      - errors:
+          - {label: unc, value: 0.00553}
+          - {label: add, value: 0.05439}
+        value: 0.09545
+      - errors:
+          - {label: unc, value: 0.00491}
+          - {label: add, value: 0.06117}
+        value: 0.07703
+      - errors:
+          - {label: unc, value: 0.00401}
+          - {label: add, value: 0.09124}
+        value: 0.05173
+      - errors:
+          - {label: unc, value: 0.03588}
+          - {label: add, value: 0.04247}
+        value: 0.88975
+      - errors:
+          - {label: unc, value: 0.02372}
+          - {label: add, value: 0.04275}
+        value: 0.62576
+      - errors:
+          - {label: unc, value: 0.01679}
+          - {label: add, value: 0.04287}
+        value: 0.43706
+      - errors:
+          - {label: unc, value: 0.01263}
+          - {label: add, value: 0.04326}
+        value: 0.31031
+      - errors:
+          - {label: unc, value: 0.00962}
+          - {label: add, value: 0.04375}
+        value: 0.22015
+      - errors:
+          - {label: unc, value: 0.00788}
+          - {label: add, value: 0.04481}
+        value: 0.16711
+      - errors:
+          - {label: unc, value: 0.00605}
+          - {label: add, value: 0.04624}
+        value: 0.11713
+      - errors:
+          - {label: unc, value: 0.00534}
+          - {label: add, value: 0.04991}
+        value: 0.09393
+      - errors:
+          - {label: unc, value: 0.00436}
+          - {label: add, value: 0.05514}
+        value: 0.06804
+      - errors:
+          - {label: unc, value: 0.00329}
+          - {label: add, value: 0.0788}
+        value: 0.04599
+      - errors:
+          - {label: unc, value: 0.06825}
+          - {label: add, value: 0.04287}
+        value: 1.83296
+      - errors:
+          - {label: unc, value: 0.04375}
+          - {label: add, value: 0.04256}
+        value: 1.23284
+      - errors:
+          - {label: unc, value: 0.03156}
+          - {label: add, value: 0.0427}
+        value: 0.85855
+      - errors:
+          - {label: unc, value: 0.02285}
+          - {label: add, value: 0.04307}
+        value: 0.58676
+      - errors:
+          - {label: unc, value: 0.01695}
+          - {label: add, value: 0.04325}
+        value: 0.40859
+      - errors:
+          - {label: unc, value: 0.01357}
+          - {label: add, value: 0.04346}
+        value: 0.30555
+      - errors:
+          - {label: unc, value: 0.01115}
+          - {label: add, value: 0.0439}
+        value: 0.22526
+      - errors:
+          - {label: unc, value: 0.00857}
+          - {label: add, value: 0.04462}
+        value: 0.14522
+      - errors:
+          - {label: unc, value: 0.00802}
+          - {label: add, value: 0.046}
+        value: 0.11373
+      - errors:
+          - {label: unc, value: 0.00791}
+          - {label: add, value: 0.04884}
+        value: 0.0914
+      - errors:
+          - {label: unc, value: 0.00739}
+          - {label: add, value: 0.05375}
+        value: 0.05849
+      - errors:
+          - {label: unc, value: 0.07481}
+          - {label: add, value: 0.04306}
+        value: 1.79426
+      - errors:
+          - {label: unc, value: 0.0554}
+          - {label: add, value: 0.04334}
+        value: 1.20518
+      - errors:
+          - {label: unc, value: 0.03915}
+          - {label: add, value: 0.04372}
+        value: 0.75179
+      - errors:
+          - {label: unc, value: 0.0365}
+          - {label: add, value: 0.044}
+        value: 0.59332
+      - errors:
+          - {label: unc, value: 0.03388}
+          - {label: add, value: 0.0449}
+        value: 0.37751
+      - errors:
+          - {label: unc, value: 0.00778}
+          - {label: add, value: 0.04612}
+        value: 0.12263
+      - errors:
+          - {label: unc, value: 0.00585}
+          - {label: add, value: 0.04755}
+        value: 0.09674
+      - errors:
+          - {label: unc, value: 0.0046}
+          - {label: add, value: 0.05388}
+        value: 0.07558
+      - errors:
+          - {label: unc, value: 0.00332}
+          - {label: add, value: 0.0742}
+        value: 0.05089
+      - errors:
+          - {label: unc, value: 0.01534}
+          - {label: add, value: 0.04253}
+        value: 0.30889
+      - errors:
+          - {label: unc, value: 0.01011}
+          - {label: add, value: 0.04309}
+        value: 0.20981
+      - errors:
+          - {label: unc, value: 0.00832}
+          - {label: add, value: 0.04375}
+        value: 0.16477
+      - errors:
+          - {label: unc, value: 0.00647}
+          - {label: add, value: 0.04474}
+        value: 0.11622
+      - errors:
+          - {label: unc, value: 0.00576}
+          - {label: add, value: 0.04705}
+        value: 0.09572
+      - errors:
+          - {label: unc, value: 0.00473}
+          - {label: add, value: 0.05073}
+        value: 0.07049
+      - errors:
+          - {label: unc, value: 0.00301}
+          - {label: add, value: 0.06425}
+        value: 0.04495
+      - errors:
+          - {label: unc, value: 0.03604}
+          - {label: add, value: 0.04195}
+        value: 0.84739
+      - errors:
+          - {label: unc, value: 0.02207}
+          - {label: add, value: 0.04189}
+        value: 0.55782
+      - errors:
+          - {label: unc, value: 0.01523}
+          - {label: add, value: 0.04207}
+        value: 0.37667
+      - errors:
+          - {label: unc, value: 0.01273}
+          - {label: add, value: 0.04235}
+        value: 0.299
+      - errors:
+          - {label: unc, value: 0.00981}
+          - {label: add, value: 0.04276}
+        value: 0.21293
+      - errors:
+          - {label: unc, value: 0.0076}
+          - {label: add, value: 0.04317}
+        value: 0.14993
+      - errors:
+          - {label: unc, value: 0.00595}
+          - {label: add, value: 0.04376}
+        value: 0.10749
+      - errors:
+          - {label: unc, value: 0.00547}
+          - {label: add, value: 0.04528}
+        value: 0.0901
+      - errors:
+          - {label: unc, value: 0.00433}
+          - {label: add, value: 0.04924}
+        value: 0.06401
+      - errors:
+          - {label: unc, value: 0.0026}
+          - {label: add, value: 0.06365}
+        value: 0.03708
+      - errors:
+          - {label: unc, value: 0.07383}
+          - {label: add, value: 0.04212}
+        value: 1.87229
+      - errors:
+          - {label: unc, value: 0.04314}
+          - {label: add, value: 0.04217}
+        value: 1.1655
+      - errors:
+          - {label: unc, value: 0.03105}
+          - {label: add, value: 0.04233}
+        value: 0.80005
+      - errors:
+          - {label: unc, value: 0.02323}
+          - {label: add, value: 0.04253}
+        value: 0.56054
+      - errors:
+          - {label: unc, value: 0.01827}
+          - {label: add, value: 0.0429}
+        value: 0.40893
+      - errors:
+          - {label: unc, value: 0.01389}
+          - {label: add, value: 0.04302}
+        value: 0.28096
+      - errors:
+          - {label: unc, value: 0.01067}
+          - {label: add, value: 0.04327}
+        value: 0.18747
+      - errors:
+          - {label: unc, value: 0.00928}
+          - {label: add, value: 0.04374}
+        value: 0.13753
+      - errors:
+          - {label: unc, value: 0.00824}
+          - {label: add, value: 0.04512}
+        value: 0.09876
+      - errors:
+          - {label: unc, value: 0.0086}
+          - {label: add, value: 0.04619}
+        value: 0.08678
+      - errors:
+          - {label: unc, value: 0.00695}
+          - {label: add, value: 0.05171}
+        value: 0.04564
+      - errors:
+          - {label: unc, value: 0.08583}
+          - {label: add, value: 0.04279}
+        value: 1.77525
+      - errors:
+          - {label: unc, value: 0.06584}
+          - {label: add, value: 0.04284}
+        value: 1.2061
+      - errors:
+          - {label: unc, value: 0.05057}
+          - {label: add, value: 0.04339}
+        value: 0.80171
+      - errors:
+          - {label: unc, value: 0.04166}
+          - {label: add, value: 0.04351}
+        value: 0.51118
+      - errors:
+          - {label: unc, value: 0.05301}
+          - {label: add, value: 0.04413}
+        value: 0.4904
+      - errors:
+          - {label: unc, value: 0.01206}
+          - {label: add, value: 0.04342}
+        value: 0.11719
+      - errors:
+          - {label: unc, value: 0.00843}
+          - {label: add, value: 0.04609}
+        value: 0.08228
+      - errors:
+          - {label: unc, value: 0.00665}
+          - {label: add, value: 0.04512}
+        value: 0.07057
+      - errors:
+          - {label: unc, value: 0.00375}
+          - {label: add, value: 0.05398}
+        value: 0.04728
+      - errors:
+          - {label: unc, value: 0.02063}
+          - {label: add, value: 0.04218}
+        value: 0.27196
+      - errors:
+          - {label: unc, value: 0.01458}
+          - {label: add, value: 0.04212}
+        value: 0.21634
+      - errors:
+          - {label: unc, value: 0.01094}
+          - {label: add, value: 0.04231}
+        value: 0.14615
+      - errors:
+          - {label: unc, value: 0.00966}
+          - {label: add, value: 0.04484}
+        value: 0.11774
+      - errors:
+          - {label: unc, value: 0.00798}
+          - {label: add, value: 0.04396}
+        value: 0.08516
+      - errors:
+          - {label: unc, value: 0.00548}
+          - {label: add, value: 0.04604}
+        value: 0.04657
+      - errors:
+          - {label: unc, value: 0.00327}
+          - {label: add, value: 0.05403}
+        value: 0.03287
+      - errors:
+          - {label: unc, value: 0.04355}
+          - {label: add, value: 0.04138}
+        value: 0.72863
+      - errors:
+          - {label: unc, value: 0.02743}
+          - {label: add, value: 0.0415}
+        value: 0.53499
+      - errors:
+          - {label: unc, value: 0.01942}
+          - {label: add, value: 0.04139}
+        value: 0.36976
+      - errors:
+          - {label: unc, value: 0.01499}
+          - {label: add, value: 0.04151}
+        value: 0.25515
+      - errors:
+          - {label: unc, value: 0.01211}
+          - {label: add, value: 0.04181}
+        value: 0.18427
+      - errors:
+          - {label: unc, value: 0.0097}
+          - {label: add, value: 0.04261}
+        value: 0.12935
+      - errors:
+          - {label: unc, value: 0.00827}
+          - {label: add, value: 0.04254}
+        value: 0.09798
+      - errors:
+          - {label: unc, value: 0.00648}
+          - {label: add, value: 0.04366}
+        value: 0.06468
+      - errors:
+          - {label: unc, value: 0.00597}
+          - {label: add, value: 0.04727}
+        value: 0.05483
+      - errors:
+          - {label: unc, value: 0.0033}
+          - {label: add, value: 0.05171}
+        value: 0.03295
+      - errors:
+          - {label: unc, value: 0.09731}
+          - {label: add, value: 0.04133}
+        value: 1.75738
+      - errors:
+          - {label: unc, value: 0.05468}
+          - {label: add, value: 0.04153}
+        value: 1.16347
+      - errors:
+          - {label: unc, value: 0.03874}
+          - {label: add, value: 0.04166}
+        value: 0.74446
+      - errors:
+          - {label: unc, value: 0.02989}
+          - {label: add, value: 0.04157}
+        value: 0.51196
+      - errors:
+          - {label: unc, value: 0.02464}
+          - {label: add, value: 0.04172}
+        value: 0.37281
+      - errors:
+          - {label: unc, value: 0.01925}
+          - {label: add, value: 0.04264}
+        value: 0.24768
+      - errors:
+          - {label: unc, value: 0.01447}
+          - {label: add, value: 0.04208}
+        value: 0.1502
+      - errors:
+          - {label: unc, value: 0.01596}
+          - {label: add, value: 0.04268}
+        value: 0.14734
+      - errors:
+          - {label: unc, value: 0.01332}
+          - {label: add, value: 0.04262}
+        value: 0.09236
+      - errors:
+          - {label: unc, value: 0.01101}
+          - {label: add, value: 0.04673}
+        value: 0.05513
+      - errors:
+          - {label: unc, value: 0.01356}
+          - {label: add, value: 0.04473}
+        value: 0.0558
+      - errors:
+          - {label: unc, value: 0.14689}
+          - {label: add, value: 0.04229}
+        value: 1.97968
+      - errors:
+          - {label: unc, value: 0.11314}
+          - {label: add, value: 0.04252}
+        value: 1.22942
+      - errors:
+          - {label: unc, value: 0.09748}
+          - {label: add, value: 0.04241}
+        value: 0.95154
+      - errors:
+          - {label: unc, value: 0.07956}
+          - {label: add, value: 0.04263}
+        value: 0.58752
+      - errors:
+          - {label: unc, value: 0.08273}
+          - {label: add, value: 0.04403}
+        value: 0.40628
+      - errors:
+          - {label: unc, value: 0.01716}
+          - {label: add, value: 0.04647}
+        value: 0.10225
+      - errors:
+          - {label: unc, value: 0.01302}
+          - {label: add, value: 0.05001}
+        value: 0.07583
+      - errors:
+          - {label: unc, value: 0.01023}
+          - {label: add, value: 0.04429}
+        value: 0.06448
+      - errors:
+          - {label: unc, value: 0.00495}
+          - {label: add, value: 0.04794}
+        value: 0.03805
+      - errors:
+          - {label: unc, value: 0.02623}
+          - {label: add, value: 0.04208}
+        value: 0.22642
+      - errors:
+          - {label: unc, value: 0.02026}
+          - {label: add, value: 0.0422}
+        value: 0.20055
+      - errors:
+          - {label: unc, value: 0.01644}
+          - {label: add, value: 0.04268}
+        value: 0.14472
+      - errors:
+          - {label: unc, value: 0.01215}
+          - {label: add, value: 0.04232}
+        value: 0.09357
+      - errors:
+          - {label: unc, value: 0.00985}
+          - {label: add, value: 0.04416}
+        value: 0.06069
+      - errors:
+          - {label: unc, value: 0.0098}
+          - {label: add, value: 0.04383}
+        value: 0.06188
+      - errors:
+          - {label: unc, value: 0.00438}
+          - {label: add, value: 0.04923}
+        value: 0.02844
+      - errors:
+          - {label: unc, value: 0.06075}
+          - {label: add, value: 0.04139}
+        value: 0.69126
+      - errors:
+          - {label: unc, value: 0.03821}
+          - {label: add, value: 0.0413}
+        value: 0.53866
+      - errors:
+          - {label: unc, value: 0.02723}
+          - {label: add, value: 0.04165}
+        value: 0.37209
+      - errors:
+          - {label: unc, value: 0.02175}
+          - {label: add, value: 0.04239}
+        value: 0.25947
+      - errors:
+          - {label: unc, value: 0.01595}
+          - {label: add, value: 0.0433}
+        value: 0.15169
+      - errors:
+          - {label: unc, value: 0.01272}
+          - {label: add, value: 0.04223}
+        value: 0.11006
+      - errors:
+          - {label: unc, value: 0.01212}
+          - {label: add, value: 0.04431}
+        value: 0.09406
+      - errors:
+          - {label: unc, value: 0.00908}
+          - {label: add, value: 0.04489}
+        value: 0.06113
+      - errors:
+          - {label: unc, value: 0.00891}
+          - {label: add, value: 0.04726}
+        value: 0.05383
+      - errors:
+          - {label: unc, value: 0.00512}
+          - {label: add, value: 0.04867}
+        value: 0.03616
+      - errors:
+          - {label: unc, value: 0.13056}
+          - {label: add, value: 0.04133}
+        value: 1.61433
+      - errors:
+          - {label: unc, value: 0.0734}
+          - {label: add, value: 0.0413}
+        value: 1.14075
+      - errors:
+          - {label: unc, value: 0.06023}
+          - {label: add, value: 0.04128}
+        value: 0.86043
+      - errors:
+          - {label: unc, value: 0.04252}
+          - {label: add, value: 0.04138}
+        value: 0.4862
+      - errors:
+          - {label: unc, value: 0.03098}
+          - {label: add, value: 0.04147}
+        value: 0.29303
+      - errors:
+          - {label: unc, value: 0.02915}
+          - {label: add, value: 0.04217}
+        value: 0.25192
+      - errors:
+          - {label: unc, value: 0.02526}
+          - {label: add, value: 0.04191}
+        value: 0.18419
+      - errors:
+          - {label: unc, value: 0.02417}
+          - {label: add, value: 0.04293}
+        value: 0.15242
+      - errors:
+          - {label: unc, value: 0.01959}
+          - {label: add, value: 0.0443}
+        value: 0.08362
+      - errors:
+          - {label: unc, value: 0.01636}
+          - {label: add, value: 0.04754}
+        value: 0.05132
+      - errors:
+          - {label: unc, value: 0.19869}
+          - {label: add, value: 0.04415}
+        value: 1.5391
+      - errors:
+          - {label: unc, value: 0.15962}
+          - {label: add, value: 0.04969}
+        value: 1.02755
+      - errors:
+          - {label: unc, value: 0.11798}
+          - {label: add, value: 0.04481}
+        value: 0.6172
+      - errors:
+          - {label: unc, value: 0.1729}
+          - {label: add, value: 0.04345}
+        value: 0.89452
+      - errors:
+          - {label: unc, value: 0.03034}
+          - {label: add, value: 0.04192}
+        value: 0.24274
+      - errors:
+          - {label: unc, value: 0.02166}
+          - {label: add, value: 0.04201}
+        value: 0.19291
+      - errors:
+          - {label: unc, value: 0.01787}
+          - {label: add, value: 0.04208}
+        value: 0.14031
+      - errors:
+          - {label: unc, value: 0.01505}
+          - {label: add, value: 0.04179}
+        value: 0.10587
+      - errors:
+          - {label: unc, value: 0.01232}
+          - {label: add, value: 0.04243}
+        value: 0.0724
+      - errors:
+          - {label: unc, value: 0.00956}
+          - {label: add, value: 0.04337}
+        value: 0.04611
+      - errors:
+          - {label: unc, value: 0.00597}
+          - {label: add, value: 0.0454}
+        value: 0.03595
+      - errors:
+          - {label: unc, value: 0.06494}
+          - {label: add, value: 0.04135}
+        value: 0.73333
+      - errors:
+          - {label: unc, value: 0.03733}
+          - {label: add, value: 0.0416}
+        value: 0.49172
+      - errors:
+          - {label: unc, value: 0.02528}
+          - {label: add, value: 0.04124}
+        value: 0.32218
+      - errors:
+          - {label: unc, value: 0.02282}
+          - {label: add, value: 0.04169}
+        value: 0.25714
+      - errors:
+          - {label: unc, value: 0.0179}
+          - {label: add, value: 0.04179}
+        value: 0.18245
+      - errors:
+          - {label: unc, value: 0.01334}
+          - {label: add, value: 0.04157}
+        value: 0.10334
+      - errors:
+          - {label: unc, value: 0.01103}
+          - {label: add, value: 0.04233}
+        value: 0.07937
+      - errors:
+          - {label: unc, value: 0.00725}
+          - {label: add, value: 0.04836}
+        value: 0.03623
+      - errors:
+          - {label: unc, value: 0.00804}
+          - {label: add, value: 0.04495}
+        value: 0.04467
+      - errors:
+          - {label: unc, value: 0.00409}
+          - {label: add, value: 0.04321}
+        value: 0.02444
+      - errors:
+          - {label: unc, value: 0.14814}
+          - {label: add, value: 0.04101}
+        value: 1.94509
+      - errors:
+          - {label: unc, value: 0.07448}
+          - {label: add, value: 0.04111}
+        value: 1.148
+      - errors:
+          - {label: unc, value: 0.05449}
+          - {label: add, value: 0.04122}
+        value: 0.738
+      - errors:
+          - {label: unc, value: 0.04657}
+          - {label: add, value: 0.0411}
+        value: 0.56545
+      - errors:
+          - {label: unc, value: 0.032}
+          - {label: add, value: 0.04118}
+        value: 0.29664
+      - errors:
+          - {label: unc, value: 0.0305}
+          - {label: add, value: 0.04223}
+        value: 0.27524
+      - errors:
+          - {label: unc, value: 0.02259}
+          - {label: add, value: 0.04168}
+        value: 0.15376
+      - errors:
+          - {label: unc, value: 0.02285}
+          - {label: add, value: 0.04264}
+        value: 0.13357
+      - errors:
+          - {label: unc, value: 0.01462}
+          - {label: add, value: 0.04652}
+        value: 0.05469
+      - errors:
+          - {label: unc, value: 0.02194}
+          - {label: add, value: 0.05003}
+        value: 0.07387
+      - errors:
+          - {label: unc, value: 0.01378}
+          - {label: add, value: 0.02478}
+        value: 0.01388
+      - errors:
+          - {label: unc, value: 0.28526}
+          - {label: add, value: 0.04219}
+        value: 1.69715
+      - errors:
+          - {label: unc, value: 0.15159}
+          - {label: add, value: 0.04135}
+        value: 0.52257
+      - errors:
+          - {label: unc, value: 0.17687}
+          - {label: add, value: 0.0419}
+        value: 0.64876
+      - errors:
+          - {label: unc, value: 0.16174}
+          - {label: add, value: 0.04667}
+        value: 0.4817
+      - errors:
+          - {label: unc, value: 0.1901}
+          - {label: add, value: 0.04158}
+        value: 0.50252
+independent_variables:
+  - header: {name: z}
+    values:
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+  - header: {name: x}
+    values:
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+  - header: {name: y}
+    values:
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+  - header: {name: Q2}
+    values:
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 28.89816}
+      - {value: 28.89816}
+      - {value: 28.89816}
+      - {value: 28.89816}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 52.377915}
+      - {value: 52.377915}
+      - {value: 52.377915}
+      - {value: 52.377915}
+      - {value: 52.377915}

--- a/data/COMPASS_PI_MINUS_2026.yaml
+++ b/data/COMPASS_PI_MINUS_2026.yaml
@@ -1,0 +1,2472 @@
+dependent_variables:
+  - header: {title: COMPASS $pi^-$ Multiplicities}
+    qualifiers:
+      - {name: process, value: SIDIS}
+      - {name: observable, value: dsigma/dxdydz}
+      - {name: target_isoscalarity, value: 0.5}
+      - {name: prefactor, value: 1}
+      - {name: Vs, value: 17.35}
+      - {name: Q, low: 0.9, high: 6.0, integrate: true}
+      - {name: x, low: 0.004, high: 0.4, integrate: true}
+      - {name: z, low: 0.2, high: 0.85, integrate: true}
+      - {name: PS_reduction, W: 5, ymin: 0.1, ymax: 0.7}
+      - {name: hadron, value: PI}
+      - {name: charge, value: -1}
+    values:
+      - errors:
+          - {label: unc, value: 0.05544}
+          - {label: add, value: 0.03678}
+        value: 1.9161
+      - errors:
+          - {label: unc, value: 0.03857}
+          - {label: add, value: 0.03663}
+        value: 1.3126
+      - errors:
+          - {label: unc, value: 0.0269}
+          - {label: add, value: 0.03658}
+        value: 0.8879
+      - errors:
+          - {label: unc, value: 0.02033}
+          - {label: add, value: 0.03661}
+        value: 0.6447
+      - errors:
+          - {label: unc, value: 0.01648}
+          - {label: add, value: 0.03712}
+        value: 0.4936
+      - errors:
+          - {label: unc, value: 0.0132}
+          - {label: add, value: 0.03814}
+        value: 0.3587
+      - errors:
+          - {label: unc, value: 0.01195}
+          - {label: add, value: 0.03903}
+        value: 0.2685
+      - errors:
+          - {label: unc, value: 0.01307}
+          - {label: add, value: 0.04486}
+        value: 0.2051
+      - errors:
+          - {label: unc, value: 0.01815}
+          - {label: add, value: 0.05634}
+        value: 0.1789
+      - errors:
+          - {label: unc, value: 0.0215}
+          - {label: add, value: 0.07687}
+        value: 0.0947
+      - errors:
+          - {label: unc, value: 0.05238}
+          - {label: add, value: 0.03659}
+        value: 1.8713
+      - errors:
+          - {label: unc, value: 0.03565}
+          - {label: add, value: 0.03648}
+        value: 1.2609
+      - errors:
+          - {label: unc, value: 0.02618}
+          - {label: add, value: 0.03662}
+        value: 0.9067
+      - errors:
+          - {label: unc, value: 0.02017}
+          - {label: add, value: 0.03701}
+        value: 0.6484
+      - errors:
+          - {label: unc, value: 0.01822}
+          - {label: add, value: 0.0371}
+        value: 0.4765
+      - errors:
+          - {label: unc, value: 0.02924}
+          - {label: add, value: 0.03722}
+        value: 0.5373
+      - errors:
+          - {label: unc, value: 0.01895}
+          - {label: add, value: 0.03749}
+        value: 0.3777
+      - errors:
+          - {label: unc, value: 0.01689}
+          - {label: add, value: 0.03882}
+        value: 0.3029
+      - errors:
+          - {label: unc, value: 0.0142}
+          - {label: add, value: 0.04724}
+        value: 0.21
+      - errors:
+          - {label: unc, value: 0.01288}
+          - {label: add, value: 0.0495}
+        value: 0.1713
+      - errors:
+          - {label: unc, value: 0.01231}
+          - {label: add, value: 0.06235}
+        value: 0.1373
+      - errors:
+          - {label: unc, value: 0.0112}
+          - {label: add, value: 0.06719}
+        value: 0.1143
+      - errors:
+          - {label: unc, value: 0.00746}
+          - {label: add, value: 0.09753}
+        value: 0.0689
+      - errors:
+          - {label: unc, value: 0.02858}
+          - {label: add, value: 0.03705}
+        value: 0.9478
+      - errors:
+          - {label: unc, value: 0.01996}
+          - {label: add, value: 0.03701}
+        value: 0.6679
+      - errors:
+          - {label: unc, value: 0.01531}
+          - {label: add, value: 0.03715}
+        value: 0.5039
+      - errors:
+          - {label: unc, value: 0.01135}
+          - {label: add, value: 0.03753}
+        value: 0.3602
+      - errors:
+          - {label: unc, value: 0.00926}
+          - {label: add, value: 0.03897}
+        value: 0.2751
+      - errors:
+          - {label: unc, value: 0.00772}
+          - {label: add, value: 0.04147}
+        value: 0.2122
+      - errors:
+          - {label: unc, value: 0.007}
+          - {label: add, value: 0.04684}
+        value: 0.1691
+      - errors:
+          - {label: unc, value: 0.00623}
+          - {label: add, value: 0.05004}
+        value: 0.1391
+      - errors:
+          - {label: unc, value: 0.00617}
+          - {label: add, value: 0.06337}
+        value: 0.1111
+      - errors:
+          - {label: unc, value: 0.005}
+          - {label: add, value: 0.08652}
+        value: 0.0712
+      - errors:
+          - {label: unc, value: 0.05383}
+          - {label: add, value: 0.03691}
+        value: 1.9053
+      - errors:
+          - {label: unc, value: 0.03683}
+          - {label: add, value: 0.03677}
+        value: 1.3119
+      - errors:
+          - {label: unc, value: 0.02592}
+          - {label: add, value: 0.03672}
+        value: 0.9171
+      - errors:
+          - {label: unc, value: 0.01891}
+          - {label: add, value: 0.0367}
+        value: 0.6627
+      - errors:
+          - {label: unc, value: 0.01354}
+          - {label: add, value: 0.0367}
+        value: 0.4665
+      - errors:
+          - {label: unc, value: 0.01044}
+          - {label: add, value: 0.03713}
+        value: 0.349
+      - errors:
+          - {label: unc, value: 0.00805}
+          - {label: add, value: 0.03785}
+        value: 0.2536
+      - errors:
+          - {label: unc, value: 0.007}
+          - {label: add, value: 0.03931}
+        value: 0.2035
+      - errors:
+          - {label: unc, value: 0.00614}
+          - {label: add, value: 0.04368}
+        value: 0.152
+      - errors:
+          - {label: unc, value: 0.00607}
+          - {label: add, value: 0.0498}
+        value: 0.1221
+      - errors:
+          - {label: unc, value: 0.00573}
+          - {label: add, value: 0.0642}
+        value: 0.081
+      - errors:
+          - {label: unc, value: 0.05201}
+          - {label: add, value: 0.03676}
+        value: 1.8498
+      - errors:
+          - {label: unc, value: 0.03535}
+          - {label: add, value: 0.03666}
+        value: 1.2459
+      - errors:
+          - {label: unc, value: 0.02546}
+          - {label: add, value: 0.03664}
+        value: 0.8822
+      - errors:
+          - {label: unc, value: 0.01862}
+          - {label: add, value: 0.0367}
+        value: 0.6126
+      - errors:
+          - {label: unc, value: 0.01604}
+          - {label: add, value: 0.03855}
+        value: 0.442
+      - errors:
+          - {label: unc, value: 0.0126}
+          - {label: add, value: 0.04672}
+        value: 0.2072
+      - errors:
+          - {label: unc, value: 0.00953}
+          - {label: add, value: 0.04521}
+        value: 0.1734
+      - errors:
+          - {label: unc, value: 0.00842}
+          - {label: add, value: 0.05619}
+        value: 0.1324
+      - errors:
+          - {label: unc, value: 0.00825}
+          - {label: add, value: 0.06755}
+        value: 0.1137
+      - errors:
+          - {label: unc, value: 0.00636}
+          - {label: add, value: 0.08323}
+        value: 0.0817
+      - errors:
+          - {label: unc, value: 0.0219}
+          - {label: add, value: 0.03716}
+        value: 0.5124
+      - errors:
+          - {label: unc, value: 0.01314}
+          - {label: add, value: 0.03766}
+        value: 0.3717
+      - errors:
+          - {label: unc, value: 0.01031}
+          - {label: add, value: 0.03861}
+        value: 0.2942
+      - errors:
+          - {label: unc, value: 0.00841}
+          - {label: add, value: 0.0414}
+        value: 0.2203
+      - errors:
+          - {label: unc, value: 0.0076}
+          - {label: add, value: 0.04623}
+        value: 0.1765
+      - errors:
+          - {label: unc, value: 0.00652}
+          - {label: add, value: 0.05103}
+        value: 0.1364
+      - errors:
+          - {label: unc, value: 0.00605}
+          - {label: add, value: 0.05978}
+        value: 0.1084
+      - errors:
+          - {label: unc, value: 0.00507}
+          - {label: add, value: 0.08627}
+        value: 0.0714
+      - errors:
+          - {label: unc, value: 0.02891}
+          - {label: add, value: 0.0371}
+        value: 0.9187
+      - errors:
+          - {label: unc, value: 0.02113}
+          - {label: add, value: 0.03693}
+        value: 0.6954
+      - errors:
+          - {label: unc, value: 0.01498}
+          - {label: add, value: 0.03695}
+        value: 0.4871
+      - errors:
+          - {label: unc, value: 0.01138}
+          - {label: add, value: 0.03699}
+        value: 0.359
+      - errors:
+          - {label: unc, value: 0.00875}
+          - {label: add, value: 0.0373}
+        value: 0.2638
+      - errors:
+          - {label: unc, value: 0.00727}
+          - {label: add, value: 0.03828}
+        value: 0.2069
+      - errors:
+          - {label: unc, value: 0.00595}
+          - {label: add, value: 0.04046}
+        value: 0.1562
+      - errors:
+          - {label: unc, value: 0.00529}
+          - {label: add, value: 0.04357}
+        value: 0.1267
+      - errors:
+          - {label: unc, value: 0.00483}
+          - {label: add, value: 0.0503}
+        value: 0.1002
+      - errors:
+          - {label: unc, value: 0.00423}
+          - {label: add, value: 0.07326}
+        value: 0.0688
+      - errors:
+          - {label: unc, value: 0.05557}
+          - {label: add, value: 0.03694}
+        value: 1.9252
+      - errors:
+          - {label: unc, value: 0.03726}
+          - {label: add, value: 0.03694}
+        value: 1.2995
+      - errors:
+          - {label: unc, value: 0.02607}
+          - {label: add, value: 0.03689}
+        value: 0.8977
+      - errors:
+          - {label: unc, value: 0.01889}
+          - {label: add, value: 0.03671}
+        value: 0.6386
+      - errors:
+          - {label: unc, value: 0.01413}
+          - {label: add, value: 0.03673}
+        value: 0.4661
+      - errors:
+          - {label: unc, value: 0.01055}
+          - {label: add, value: 0.03675}
+        value: 0.3352
+      - errors:
+          - {label: unc, value: 0.0081}
+          - {label: add, value: 0.03688}
+        value: 0.2386
+      - errors:
+          - {label: unc, value: 0.00702}
+          - {label: add, value: 0.03776}
+        value: 0.1843
+      - errors:
+          - {label: unc, value: 0.00611}
+          - {label: add, value: 0.03853}
+        value: 0.1391
+      - errors:
+          - {label: unc, value: 0.00581}
+          - {label: add, value: 0.0429}
+        value: 0.1063
+      - errors:
+          - {label: unc, value: 0.00624}
+          - {label: add, value: 0.05042}
+        value: 0.0825
+      - errors:
+          - {label: unc, value: 0.05318}
+          - {label: add, value: 0.03692}
+        value: 1.8245
+      - errors:
+          - {label: unc, value: 0.03646}
+          - {label: add, value: 0.0368}
+        value: 1.2195
+      - errors:
+          - {label: unc, value: 0.02634}
+          - {label: add, value: 0.03681}
+        value: 0.8454
+      - errors:
+          - {label: unc, value: 0.02085}
+          - {label: add, value: 0.03778}
+        value: 0.5992
+      - errors:
+          - {label: unc, value: 0.01844}
+          - {label: add, value: 0.03918}
+        value: 0.4084
+      - errors:
+          - {label: unc, value: 0.0131}
+          - {label: add, value: 0.04074}
+        value: 0.2278
+      - errors:
+          - {label: unc, value: 0.00876}
+          - {label: add, value: 0.04413}
+        value: 0.1704
+      - errors:
+          - {label: unc, value: 0.00694}
+          - {label: add, value: 0.0491}
+        value: 0.1336
+      - errors:
+          - {label: unc, value: 0.00664}
+          - {label: add, value: 0.06327}
+        value: 0.11
+      - errors:
+          - {label: unc, value: 0.00527}
+          - {label: add, value: 0.08438}
+        value: 0.0749
+      - errors:
+          - {label: unc, value: 0.02482}
+          - {label: add, value: 0.03739}
+        value: 0.4771
+      - errors:
+          - {label: unc, value: 0.01519}
+          - {label: add, value: 0.03762}
+        value: 0.3785
+      - errors:
+          - {label: unc, value: 0.01059}
+          - {label: add, value: 0.03775}
+        value: 0.2776
+      - errors:
+          - {label: unc, value: 0.00844}
+          - {label: add, value: 0.03896}
+        value: 0.2033
+      - errors:
+          - {label: unc, value: 0.00716}
+          - {label: add, value: 0.04077}
+        value: 0.1609
+      - errors:
+          - {label: unc, value: 0.00607}
+          - {label: add, value: 0.04545}
+        value: 0.1197
+      - errors:
+          - {label: unc, value: 0.00596}
+          - {label: add, value: 0.05019}
+        value: 0.1068
+      - errors:
+          - {label: unc, value: 0.00448}
+          - {label: add, value: 0.07262}
+        value: 0.0683
+      - errors:
+          - {label: unc, value: 0.03026}
+          - {label: add, value: 0.03736}
+        value: 0.9165
+      - errors:
+          - {label: unc, value: 0.02101}
+          - {label: add, value: 0.03732}
+        value: 0.6581
+      - errors:
+          - {label: unc, value: 0.01539}
+          - {label: add, value: 0.03718}
+        value: 0.4777
+      - errors:
+          - {label: unc, value: 0.0116}
+          - {label: add, value: 0.03708}
+        value: 0.343
+      - errors:
+          - {label: unc, value: 0.00892}
+          - {label: add, value: 0.03735}
+        value: 0.2506
+      - errors:
+          - {label: unc, value: 0.00729}
+          - {label: add, value: 0.03744}
+        value: 0.1923
+      - errors:
+          - {label: unc, value: 0.00603}
+          - {label: add, value: 0.03866}
+        value: 0.149
+      - errors:
+          - {label: unc, value: 0.00515}
+          - {label: add, value: 0.04121}
+        value: 0.1126
+      - errors:
+          - {label: unc, value: 0.00457}
+          - {label: add, value: 0.04569}
+        value: 0.0893
+      - errors:
+          - {label: unc, value: 0.00326}
+          - {label: add, value: 0.0586}
+        value: 0.0587
+      - errors:
+          - {label: unc, value: 0.05658}
+          - {label: add, value: 0.03735}
+        value: 1.8936
+      - errors:
+          - {label: unc, value: 0.03686}
+          - {label: add, value: 0.03733}
+        value: 1.2472
+      - errors:
+          - {label: unc, value: 0.02635}
+          - {label: add, value: 0.0372}
+        value: 0.8753
+      - errors:
+          - {label: unc, value: 0.01938}
+          - {label: add, value: 0.0371}
+        value: 0.6275
+      - errors:
+          - {label: unc, value: 0.01399}
+          - {label: add, value: 0.03703}
+        value: 0.4343
+      - errors:
+          - {label: unc, value: 0.01078}
+          - {label: add, value: 0.03713}
+        value: 0.3167
+      - errors:
+          - {label: unc, value: 0.0089}
+          - {label: add, value: 0.03714}
+        value: 0.2391
+      - errors:
+          - {label: unc, value: 0.00722}
+          - {label: add, value: 0.03741}
+        value: 0.1668
+      - errors:
+          - {label: unc, value: 0.00648}
+          - {label: add, value: 0.03851}
+        value: 0.1288
+      - errors:
+          - {label: unc, value: 0.00629}
+          - {label: add, value: 0.0442}
+        value: 0.0923
+      - errors:
+          - {label: unc, value: 0.0066}
+          - {label: add, value: 0.04486}
+        value: 0.0749
+      - errors:
+          - {label: unc, value: 0.05579}
+          - {label: add, value: 0.0372}
+        value: 1.815
+      - errors:
+          - {label: unc, value: 0.03962}
+          - {label: add, value: 0.03711}
+        value: 1.233
+      - errors:
+          - {label: unc, value: 0.03004}
+          - {label: add, value: 0.03705}
+        value: 0.8787
+      - errors:
+          - {label: unc, value: 0.0229}
+          - {label: add, value: 0.03747}
+        value: 0.5722
+      - errors:
+          - {label: unc, value: 0.02383}
+          - {label: add, value: 0.03991}
+        value: 0.433
+      - errors:
+          - {label: unc, value: 0.01129}
+          - {label: add, value: 0.03822}
+        value: 0.2072
+      - errors:
+          - {label: unc, value: 0.00757}
+          - {label: add, value: 0.03995}
+        value: 0.1582
+      - errors:
+          - {label: unc, value: 0.00625}
+          - {label: add, value: 0.04658}
+        value: 0.1271
+      - errors:
+          - {label: unc, value: 0.00529}
+          - {label: add, value: 0.05048}
+        value: 0.1046
+      - errors:
+          - {label: unc, value: 0.00428}
+          - {label: add, value: 0.07596}
+        value: 0.0674
+      - errors:
+          - {label: unc, value: 0.02143}
+          - {label: add, value: 0.03754}
+        value: 0.4539
+      - errors:
+          - {label: unc, value: 0.0128}
+          - {label: add, value: 0.03746}
+        value: 0.3374
+      - errors:
+          - {label: unc, value: 0.00967}
+          - {label: add, value: 0.03736}
+        value: 0.2677
+      - errors:
+          - {label: unc, value: 0.00776}
+          - {label: add, value: 0.03787}
+        value: 0.2028
+      - errors:
+          - {label: unc, value: 0.00636}
+          - {label: add, value: 0.03866}
+        value: 0.1552
+      - errors:
+          - {label: unc, value: 0.00504}
+          - {label: add, value: 0.03979}
+        value: 0.1146
+      - errors:
+          - {label: unc, value: 0.0047}
+          - {label: add, value: 0.04576}
+        value: 0.0944
+      - errors:
+          - {label: unc, value: 0.00341}
+          - {label: add, value: 0.05814}
+        value: 0.0633
+      - errors:
+          - {label: unc, value: 0.02806}
+          - {label: add, value: 0.03763}
+        value: 0.8717
+      - errors:
+          - {label: unc, value: 0.02001}
+          - {label: add, value: 0.03764}
+        value: 0.6419
+      - errors:
+          - {label: unc, value: 0.01409}
+          - {label: add, value: 0.03759}
+        value: 0.4469
+      - errors:
+          - {label: unc, value: 0.01065}
+          - {label: add, value: 0.03757}
+        value: 0.3258
+      - errors:
+          - {label: unc, value: 0.00814}
+          - {label: add, value: 0.03769}
+        value: 0.2377
+      - errors:
+          - {label: unc, value: 0.00643}
+          - {label: add, value: 0.03782}
+        value: 0.1777
+      - errors:
+          - {label: unc, value: 0.00517}
+          - {label: add, value: 0.0381}
+        value: 0.1365
+      - errors:
+          - {label: unc, value: 0.00448}
+          - {label: add, value: 0.03927}
+        value: 0.11
+      - errors:
+          - {label: unc, value: 0.00358}
+          - {label: add, value: 0.04333}
+        value: 0.0757
+      - errors:
+          - {label: unc, value: 0.00268}
+          - {label: add, value: 0.05585}
+        value: 0.053
+      - errors:
+          - {label: unc, value: 0.05522}
+          - {label: add, value: 0.03772}
+        value: 1.8454
+      - errors:
+          - {label: unc, value: 0.03675}
+          - {label: add, value: 0.03767}
+        value: 1.2445
+      - errors:
+          - {label: unc, value: 0.02573}
+          - {label: add, value: 0.03758}
+        value: 0.858
+      - errors:
+          - {label: unc, value: 0.01834}
+          - {label: add, value: 0.03749}
+        value: 0.5953
+      - errors:
+          - {label: unc, value: 0.01345}
+          - {label: add, value: 0.03746}
+        value: 0.4228
+      - errors:
+          - {label: unc, value: 0.01004}
+          - {label: add, value: 0.03733}
+        value: 0.3
+      - errors:
+          - {label: unc, value: 0.00801}
+          - {label: add, value: 0.03744}
+        value: 0.2201
+      - errors:
+          - {label: unc, value: 0.00673}
+          - {label: add, value: 0.03765}
+        value: 0.1636
+      - errors:
+          - {label: unc, value: 0.00593}
+          - {label: add, value: 0.03883}
+        value: 0.1195
+      - errors:
+          - {label: unc, value: 0.00559}
+          - {label: add, value: 0.04031}
+        value: 0.0893
+      - errors:
+          - {label: unc, value: 0.00559}
+          - {label: add, value: 0.04172}
+        value: 0.0652
+      - errors:
+          - {label: unc, value: 0.05751}
+          - {label: add, value: 0.03733}
+        value: 1.8432
+      - errors:
+          - {label: unc, value: 0.03844}
+          - {label: add, value: 0.03722}
+        value: 1.1629
+      - errors:
+          - {label: unc, value: 0.02899}
+          - {label: add, value: 0.03718}
+        value: 0.8176
+      - errors:
+          - {label: unc, value: 0.02338}
+          - {label: add, value: 0.03714}
+        value: 0.5686
+      - errors:
+          - {label: unc, value: 0.02256}
+          - {label: add, value: 0.03851}
+        value: 0.3989
+      - errors:
+          - {label: unc, value: 0.01019}
+          - {label: add, value: 0.03808}
+        value: 0.1912
+      - errors:
+          - {label: unc, value: 0.00665}
+          - {label: add, value: 0.03863}
+        value: 0.1429
+      - errors:
+          - {label: unc, value: 0.00503}
+          - {label: add, value: 0.04089}
+        value: 0.1076
+      - errors:
+          - {label: unc, value: 0.00405}
+          - {label: add, value: 0.04514}
+        value: 0.0833
+      - errors:
+          - {label: unc, value: 0.00324}
+          - {label: add, value: 0.05875}
+        value: 0.064
+      - errors:
+          - {label: unc, value: 0.02028}
+          - {label: add, value: 0.03817}
+        value: 0.4443
+      - errors:
+          - {label: unc, value: 0.01176}
+          - {label: add, value: 0.03771}
+        value: 0.3203
+      - errors:
+          - {label: unc, value: 0.00861}
+          - {label: add, value: 0.0376}
+        value: 0.2404
+      - errors:
+          - {label: unc, value: 0.00658}
+          - {label: add, value: 0.03773}
+        value: 0.176
+      - errors:
+          - {label: unc, value: 0.00545}
+          - {label: add, value: 0.03796}
+        value: 0.137
+      - errors:
+          - {label: unc, value: 0.0045}
+          - {label: add, value: 0.03889}
+        value: 0.1049
+      - errors:
+          - {label: unc, value: 0.00373}
+          - {label: add, value: 0.04136}
+        value: 0.0793
+      - errors:
+          - {label: unc, value: 0.00244}
+          - {label: add, value: 0.05079}
+        value: 0.0504
+      - errors:
+          - {label: unc, value: 0.02804}
+          - {label: add, value: 0.03823}
+        value: 0.8663
+      - errors:
+          - {label: unc, value: 0.01843}
+          - {label: add, value: 0.03806}
+        value: 0.5865
+      - errors:
+          - {label: unc, value: 0.01333}
+          - {label: add, value: 0.0379}
+        value: 0.4222
+      - errors:
+          - {label: unc, value: 0.01003}
+          - {label: add, value: 0.0377}
+        value: 0.3077
+      - errors:
+          - {label: unc, value: 0.00762}
+          - {label: add, value: 0.03776}
+        value: 0.2246
+      - errors:
+          - {label: unc, value: 0.00611}
+          - {label: add, value: 0.0377}
+        value: 0.1719
+      - errors:
+          - {label: unc, value: 0.0045}
+          - {label: add, value: 0.03755}
+        value: 0.1193
+      - errors:
+          - {label: unc, value: 0.00378}
+          - {label: add, value: 0.03881}
+        value: 0.0907
+      - errors:
+          - {label: unc, value: 0.00315}
+          - {label: add, value: 0.03994}
+        value: 0.0681
+      - errors:
+          - {label: unc, value: 0.00219}
+          - {label: add, value: 0.04797}
+        value: 0.0467
+      - errors:
+          - {label: unc, value: 0.05727}
+          - {label: add, value: 0.03831}
+        value: 1.8417
+      - errors:
+          - {label: unc, value: 0.03697}
+          - {label: add, value: 0.0382}
+        value: 1.2229
+      - errors:
+          - {label: unc, value: 0.02596}
+          - {label: add, value: 0.03813}
+        value: 0.8434
+      - errors:
+          - {label: unc, value: 0.0187}
+          - {label: add, value: 0.03801}
+        value: 0.5915
+      - errors:
+          - {label: unc, value: 0.01338}
+          - {label: add, value: 0.03786}
+        value: 0.4057
+      - errors:
+          - {label: unc, value: 0.00986}
+          - {label: add, value: 0.03797}
+        value: 0.2823
+      - errors:
+          - {label: unc, value: 0.0083}
+          - {label: add, value: 0.03875}
+        value: 0.2168
+      - errors:
+          - {label: unc, value: 0.00677}
+          - {label: add, value: 0.03863}
+        value: 0.1574
+      - errors:
+          - {label: unc, value: 0.00559}
+          - {label: add, value: 0.03876}
+        value: 0.1094
+      - errors:
+          - {label: unc, value: 0.00542}
+          - {label: add, value: 0.04343}
+        value: 0.0829
+      - errors:
+          - {label: unc, value: 0.00528}
+          - {label: add, value: 0.04681}
+        value: 0.0564
+      - errors:
+          - {label: unc, value: 0.06069}
+          - {label: add, value: 0.03805}
+        value: 1.764
+      - errors:
+          - {label: unc, value: 0.04536}
+          - {label: add, value: 0.03796}
+        value: 1.2225
+      - errors:
+          - {label: unc, value: 0.03284}
+          - {label: add, value: 0.03785}
+        value: 0.782
+      - errors:
+          - {label: unc, value: 0.02723}
+          - {label: add, value: 0.03799}
+        value: 0.5433
+      - errors:
+          - {label: unc, value: 0.02883}
+          - {label: add, value: 0.0383}
+        value: 0.4031
+      - errors:
+          - {label: unc, value: 0.01189}
+          - {label: add, value: 0.03854}
+        value: 0.164
+      - errors:
+          - {label: unc, value: 0.00723}
+          - {label: add, value: 0.03839}
+        value: 0.1167
+      - errors:
+          - {label: unc, value: 0.00513}
+          - {label: add, value: 0.03877}
+        value: 0.0846
+      - errors:
+          - {label: unc, value: 0.00449}
+          - {label: add, value: 0.04108}
+        value: 0.0779
+      - errors:
+          - {label: unc, value: 0.00281}
+          - {label: add, value: 0.05057}
+        value: 0.0522
+      - errors:
+          - {label: unc, value: 0.02253}
+          - {label: add, value: 0.03842}
+        value: 0.3915
+      - errors:
+          - {label: unc, value: 0.01306}
+          - {label: add, value: 0.03825}
+        value: 0.3012
+      - errors:
+          - {label: unc, value: 0.00927}
+          - {label: add, value: 0.0381}
+        value: 0.2205
+      - errors:
+          - {label: unc, value: 0.0068}
+          - {label: add, value: 0.03835}
+        value: 0.1481
+      - errors:
+          - {label: unc, value: 0.00555}
+          - {label: add, value: 0.03847}
+        value: 0.1123
+      - errors:
+          - {label: unc, value: 0.00464}
+          - {label: add, value: 0.03827}
+        value: 0.0878
+      - errors:
+          - {label: unc, value: 0.00405}
+          - {label: add, value: 0.04012}
+        value: 0.0678
+      - errors:
+          - {label: unc, value: 0.00238}
+          - {label: add, value: 0.04793}
+        value: 0.0434
+      - errors:
+          - {label: unc, value: 0.03069}
+          - {label: add, value: 0.0388}
+        value: 0.8144
+      - errors:
+          - {label: unc, value: 0.0204}
+          - {label: add, value: 0.03848}
+        value: 0.5863
+      - errors:
+          - {label: unc, value: 0.01461}
+          - {label: add, value: 0.03822}
+        value: 0.4144
+      - errors:
+          - {label: unc, value: 0.01109}
+          - {label: add, value: 0.0382}
+        value: 0.2974
+      - errors:
+          - {label: unc, value: 0.00849}
+          - {label: add, value: 0.03806}
+        value: 0.2102
+      - errors:
+          - {label: unc, value: 0.00638}
+          - {label: add, value: 0.03802}
+        value: 0.1431
+      - errors:
+          - {label: unc, value: 0.00554}
+          - {label: add, value: 0.03816}
+        value: 0.1174
+      - errors:
+          - {label: unc, value: 0.00441}
+          - {label: add, value: 0.03832}
+        value: 0.0835
+      - errors:
+          - {label: unc, value: 0.00367}
+          - {label: add, value: 0.03896}
+        value: 0.0616
+      - errors:
+          - {label: unc, value: 0.0022}
+          - {label: add, value: 0.04433}
+        value: 0.0379
+      - errors:
+          - {label: unc, value: 0.0663}
+          - {label: add, value: 0.03817}
+        value: 1.8173
+      - errors:
+          - {label: unc, value: 0.04018}
+          - {label: add, value: 0.03841}
+        value: 1.1894
+      - errors:
+          - {label: unc, value: 0.02872}
+          - {label: add, value: 0.03829}
+        value: 0.8085
+      - errors:
+          - {label: unc, value: 0.02168}
+          - {label: add, value: 0.03831}
+        value: 0.5701
+      - errors:
+          - {label: unc, value: 0.01628}
+          - {label: add, value: 0.03827}
+        value: 0.3909
+      - errors:
+          - {label: unc, value: 0.01295}
+          - {label: add, value: 0.03853}
+        value: 0.2803
+      - errors:
+          - {label: unc, value: 0.0114}
+          - {label: add, value: 0.0397}
+        value: 0.2116
+      - errors:
+          - {label: unc, value: 0.01029}
+          - {label: add, value: 0.03941}
+        value: 0.1624
+      - errors:
+          - {label: unc, value: 0.00829}
+          - {label: add, value: 0.0408}
+        value: 0.1
+      - errors:
+          - {label: unc, value: 0.00852}
+          - {label: add, value: 0.05121}
+        value: 0.0828
+      - errors:
+          - {label: unc, value: 0.00702}
+          - {label: add, value: 0.05408}
+        value: 0.0429
+      - errors:
+          - {label: unc, value: 0.08603}
+          - {label: add, value: 0.03855}
+        value: 1.8136
+      - errors:
+          - {label: unc, value: 0.06148}
+          - {label: add, value: 0.03848}
+        value: 1.0914
+      - errors:
+          - {label: unc, value: 0.05192}
+          - {label: add, value: 0.03859}
+        value: 0.7837
+      - errors:
+          - {label: unc, value: 0.04523}
+          - {label: add, value: 0.04483}
+        value: 0.5282
+      - errors:
+          - {label: unc, value: 0.04848}
+          - {label: add, value: 0.04836}
+        value: 0.3689
+      - errors:
+          - {label: unc, value: 0.01346}
+          - {label: add, value: 0.03804}
+        value: 0.1346
+      - errors:
+          - {label: unc, value: 0.00875}
+          - {label: add, value: 0.03849}
+        value: 0.106
+      - errors:
+          - {label: unc, value: 0.00628}
+          - {label: add, value: 0.0382}
+        value: 0.0754
+      - errors:
+          - {label: unc, value: 0.00549}
+          - {label: add, value: 0.03965}
+        value: 0.0686
+      - errors:
+          - {label: unc, value: 0.00292}
+          - {label: add, value: 0.04608}
+        value: 0.0434
+      - errors:
+          - {label: unc, value: 0.02796}
+          - {label: add, value: 0.03877}
+        value: 0.3446
+      - errors:
+          - {label: unc, value: 0.01571}
+          - {label: add, value: 0.03893}
+        value: 0.2754
+      - errors:
+          - {label: unc, value: 0.01065}
+          - {label: add, value: 0.0384}
+        value: 0.1979
+      - errors:
+          - {label: unc, value: 0.00816}
+          - {label: add, value: 0.03829}
+        value: 0.14
+      - errors:
+          - {label: unc, value: 0.007}
+          - {label: add, value: 0.03831}
+        value: 0.1065
+      - errors:
+          - {label: unc, value: 0.00582}
+          - {label: add, value: 0.03922}
+        value: 0.0816
+      - errors:
+          - {label: unc, value: 0.00496}
+          - {label: add, value: 0.04059}
+        value: 0.0611
+      - errors:
+          - {label: unc, value: 0.00259}
+          - {label: add, value: 0.04457}
+        value: 0.0359
+      - errors:
+          - {label: unc, value: 0.03873}
+          - {label: add, value: 0.03916}
+        value: 0.8213
+      - errors:
+          - {label: unc, value: 0.02229}
+          - {label: add, value: 0.03888}
+        value: 0.5288
+      - errors:
+          - {label: unc, value: 0.01681}
+          - {label: add, value: 0.03862}
+        value: 0.3957
+      - errors:
+          - {label: unc, value: 0.01291}
+          - {label: add, value: 0.03851}
+        value: 0.2742
+      - errors:
+          - {label: unc, value: 0.0103}
+          - {label: add, value: 0.03866}
+        value: 0.2007
+      - errors:
+          - {label: unc, value: 0.00766}
+          - {label: add, value: 0.03845}
+        value: 0.129
+      - errors:
+          - {label: unc, value: 0.00666}
+          - {label: add, value: 0.03817}
+        value: 0.1006
+      - errors:
+          - {label: unc, value: 0.00533}
+          - {label: add, value: 0.03905}
+        value: 0.0717
+      - errors:
+          - {label: unc, value: 0.00457}
+          - {label: add, value: 0.03954}
+        value: 0.0526
+      - errors:
+          - {label: unc, value: 0.00263}
+          - {label: add, value: 0.04472}
+        value: 0.0322
+      - errors:
+          - {label: unc, value: 0.08141}
+          - {label: add, value: 0.03863}
+        value: 1.7543
+      - errors:
+          - {label: unc, value: 0.04867}
+          - {label: add, value: 0.03882}
+        value: 1.1995
+      - errors:
+          - {label: unc, value: 0.0343}
+          - {label: add, value: 0.03877}
+        value: 0.7655
+      - errors:
+          - {label: unc, value: 0.02769}
+          - {label: add, value: 0.03862}
+        value: 0.5572
+      - errors:
+          - {label: unc, value: 0.02204}
+          - {label: add, value: 0.03889}
+        value: 0.3888
+      - errors:
+          - {label: unc, value: 0.02}
+          - {label: add, value: 0.03902}
+        value: 0.3116
+      - errors:
+          - {label: unc, value: 0.01675}
+          - {label: add, value: 0.0404}
+        value: 0.2178
+      - errors:
+          - {label: unc, value: 0.01399}
+          - {label: add, value: 0.0424}
+        value: 0.1453
+      - errors:
+          - {label: unc, value: 0.01172}
+          - {label: add, value: 0.04658}
+        value: 0.0893
+      - errors:
+          - {label: unc, value: 0.01248}
+          - {label: add, value: 0.04903}
+        value: 0.0718
+      - errors:
+          - {label: unc, value: 0.01206}
+          - {label: add, value: 0.05535}
+        value: 0.0477
+      - errors:
+          - {label: unc, value: 0.0309}
+          - {label: add, value: 0.03913}
+        value: 0.3639
+      - errors:
+          - {label: unc, value: 0.01678}
+          - {label: add, value: 0.03925}
+        value: 0.2813
+      - errors:
+          - {label: unc, value: 0.01178}
+          - {label: add, value: 0.0389}
+        value: 0.2077
+      - errors:
+          - {label: unc, value: 0.00883}
+          - {label: add, value: 0.03885}
+        value: 0.1421
+      - errors:
+          - {label: unc, value: 0.00737}
+          - {label: add, value: 0.03897}
+        value: 0.1047
+      - errors:
+          - {label: unc, value: 0.00614}
+          - {label: add, value: 0.03878}
+        value: 0.0784
+      - errors:
+          - {label: unc, value: 0.00484}
+          - {label: add, value: 0.03945}
+        value: 0.0507
+      - errors:
+          - {label: unc, value: 0.00249}
+          - {label: add, value: 0.04324}
+        value: 0.0296
+      - errors:
+          - {label: unc, value: 0.03855}
+          - {label: add, value: 0.03988}
+        value: 0.7522
+      - errors:
+          - {label: unc, value: 0.02307}
+          - {label: add, value: 0.03956}
+        value: 0.5218
+      - errors:
+          - {label: unc, value: 0.01617}
+          - {label: add, value: 0.0394}
+        value: 0.3553
+      - errors:
+          - {label: unc, value: 0.01297}
+          - {label: add, value: 0.03918}
+        value: 0.2593
+      - errors:
+          - {label: unc, value: 0.01059}
+          - {label: add, value: 0.03908}
+        value: 0.1904
+      - errors:
+          - {label: unc, value: 0.00851}
+          - {label: add, value: 0.03918}
+        value: 0.1368
+      - errors:
+          - {label: unc, value: 0.0073}
+          - {label: add, value: 0.03895}
+        value: 0.1068
+      - errors:
+          - {label: unc, value: 0.00528}
+          - {label: add, value: 0.03994}
+        value: 0.0661
+      - errors:
+          - {label: unc, value: 0.00465}
+          - {label: add, value: 0.03984}
+        value: 0.0502
+      - errors:
+          - {label: unc, value: 0.00247}
+          - {label: add, value: 0.04545}
+        value: 0.0264
+      - errors:
+          - {label: unc, value: 0.08659}
+          - {label: add, value: 0.03899}
+        value: 1.7708
+      - errors:
+          - {label: unc, value: 0.04668}
+          - {label: add, value: 0.03909}
+        value: 1.1196
+      - errors:
+          - {label: unc, value: 0.03426}
+          - {label: add, value: 0.03905}
+        value: 0.7539
+      - errors:
+          - {label: unc, value: 0.02622}
+          - {label: add, value: 0.03913}
+        value: 0.5111
+      - errors:
+          - {label: unc, value: 0.02134}
+          - {label: add, value: 0.0391}
+        value: 0.3683
+      - errors:
+          - {label: unc, value: 0.01805}
+          - {label: add, value: 0.03953}
+        value: 0.2752
+      - errors:
+          - {label: unc, value: 0.01546}
+          - {label: add, value: 0.0409}
+        value: 0.1995
+      - errors:
+          - {label: unc, value: 0.01366}
+          - {label: add, value: 0.0424}
+        value: 0.1415
+      - errors:
+          - {label: unc, value: 0.01363}
+          - {label: add, value: 0.04768}
+        value: 0.1141
+      - errors:
+          - {label: unc, value: 0.01194}
+          - {label: add, value: 0.0496}
+        value: 0.0758
+independent_variables:
+  - header: {name: z}
+    values:
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+  - header: {name: x}
+    values:
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+  - header: {name: y}
+    values:
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+  - header: {name: Q2}
+    values:
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}

--- a/data/COMPASS_PI_PLUS_2025.yaml
+++ b/data/COMPASS_PI_PLUS_2025.yaml
@@ -1,0 +1,2440 @@
+dependent_variables:
+  - header: {title: COMPASS $pi^+$ Multiplicities}
+    qualifiers:
+      - {name: process, value: SIDIS}
+      - {name: observable, value: dsigma/dxdydz}
+      - {name: target_isoscalarity, value: 1.0}
+      - {name: prefactor, value: 1}
+      - {name: Vs, value: 17.35}
+      - {name: Q, low: 0.9, high: 8.0, integrate: true}
+      - {name: x, low: 0.004, high: 0.4, integrate: true}
+      - {name: z, low: 0.2, high: 0.85, integrate: true}
+      - {name: PS_reduction, W: 5, ymin: 0.1, ymax: 0.7}
+      - {name: hadron, value: PI}
+      - {name: charge, value: 1}
+    values:
+      - errors:
+          - {label: unc, value: 0.07824}
+          - {label: add, value: 0.04636}
+        value: 2.15047
+      - errors:
+          - {label: unc, value: 0.0549}
+          - {label: add, value: 0.04644}
+        value: 1.48649
+      - errors:
+          - {label: unc, value: 0.03995}
+          - {label: add, value: 0.04681}
+        value: 1.0496
+      - errors:
+          - {label: unc, value: 0.02936}
+          - {label: add, value: 0.04732}
+        value: 0.74042
+      - errors:
+          - {label: unc, value: 0.02318}
+          - {label: add, value: 0.0481}
+        value: 0.55972
+      - errors:
+          - {label: unc, value: 0.01747}
+          - {label: add, value: 0.0494}
+        value: 0.393
+      - errors:
+          - {label: unc, value: 0.01601}
+          - {label: add, value: 0.05246}
+        value: 0.31077
+      - errors:
+          - {label: unc, value: 0.01578}
+          - {label: add, value: 0.06231}
+        value: 0.23096
+      - errors:
+          - {label: unc, value: 0.08068}
+          - {label: add, value: 0.04967}
+        value: 2.11931
+      - errors:
+          - {label: unc, value: 0.05608}
+          - {label: add, value: 0.04993}
+        value: 1.45023
+      - errors:
+          - {label: unc, value: 0.04066}
+          - {label: add, value: 0.05014}
+        value: 1.03265
+      - errors:
+          - {label: unc, value: 0.03004}
+          - {label: add, value: 0.04993}
+        value: 0.73136
+      - errors:
+          - {label: unc, value: 0.02636}
+          - {label: add, value: 0.05048}
+        value: 0.55625
+      - errors:
+          - {label: unc, value: 0.03394}
+          - {label: add, value: 0.04614}
+        value: 0.55503
+      - errors:
+          - {label: unc, value: 0.02357}
+          - {label: add, value: 0.04773}
+        value: 0.43261
+      - errors:
+          - {label: unc, value: 0.01905}
+          - {label: add, value: 0.04914}
+        value: 0.31597
+      - errors:
+          - {label: unc, value: 0.01673}
+          - {label: add, value: 0.05489}
+        value: 0.25216
+      - errors:
+          - {label: unc, value: 0.01466}
+          - {label: add, value: 0.057}
+        value: 0.20338
+      - errors:
+          - {label: unc, value: 0.01262}
+          - {label: add, value: 0.07668}
+        value: 0.14533
+      - errors:
+          - {label: unc, value: 0.01275}
+          - {label: add, value: 0.10476}
+        value: 0.12211
+      - errors:
+          - {label: unc, value: 0.00951}
+          - {label: add, value: 0.15758}
+        value: 0.07265
+      - errors:
+          - {label: unc, value: 0.03824}
+          - {label: add, value: 0.04404}
+        value: 1.08282
+      - errors:
+          - {label: unc, value: 0.02735}
+          - {label: add, value: 0.04448}
+        value: 0.77546
+      - errors:
+          - {label: unc, value: 0.02081}
+          - {label: add, value: 0.04533}
+        value: 0.57515
+      - errors:
+          - {label: unc, value: 0.0158}
+          - {label: add, value: 0.04639}
+        value: 0.41954
+      - errors:
+          - {label: unc, value: 0.01292}
+          - {label: add, value: 0.04901}
+        value: 0.32141
+      - errors:
+          - {label: unc, value: 0.0107}
+          - {label: add, value: 0.05292}
+        value: 0.24444
+      - errors:
+          - {label: unc, value: 0.00939}
+          - {label: add, value: 0.0593}
+        value: 0.19157
+      - errors:
+          - {label: unc, value: 0.00815}
+          - {label: add, value: 0.07084}
+        value: 0.14071
+      - errors:
+          - {label: unc, value: 0.00838}
+          - {label: add, value: 0.09717}
+        value: 0.10868
+      - errors:
+          - {label: unc, value: 0.00804}
+          - {label: add, value: 0.15147}
+        value: 0.06961
+      - errors:
+          - {label: unc, value: 0.07285}
+          - {label: add, value: 0.0441}
+        value: 2.14879
+      - errors:
+          - {label: unc, value: 0.05001}
+          - {label: add, value: 0.04417}
+        value: 1.48282
+      - errors:
+          - {label: unc, value: 0.03535}
+          - {label: add, value: 0.04442}
+        value: 1.03559
+      - errors:
+          - {label: unc, value: 0.02619}
+          - {label: add, value: 0.04478}
+        value: 0.75444
+      - errors:
+          - {label: unc, value: 0.01949}
+          - {label: add, value: 0.04539}
+        value: 0.54797
+      - errors:
+          - {label: unc, value: 0.01475}
+          - {label: add, value: 0.04638}
+        value: 0.40048
+      - errors:
+          - {label: unc, value: 0.01195}
+          - {label: add, value: 0.04831}
+        value: 0.30605
+      - errors:
+          - {label: unc, value: 0.00992}
+          - {label: add, value: 0.05134}
+        value: 0.23326
+      - errors:
+          - {label: unc, value: 0.00874}
+          - {label: add, value: 0.05871}
+        value: 0.17659
+      - errors:
+          - {label: unc, value: 0.00814}
+          - {label: add, value: 0.06751}
+        value: 0.139
+      - errors:
+          - {label: unc, value: 0.00837}
+          - {label: add, value: 0.08655}
+        value: 0.10944
+      - errors:
+          - {label: unc, value: 0.07574}
+          - {label: add, value: 0.04596}
+        value: 2.13139
+      - errors:
+          - {label: unc, value: 0.05159}
+          - {label: add, value: 0.04619}
+        value: 1.42354
+      - errors:
+          - {label: unc, value: 0.03701}
+          - {label: add, value: 0.04643}
+        value: 0.99683
+      - errors:
+          - {label: unc, value: 0.029}
+          - {label: add, value: 0.04647}
+        value: 0.74555
+      - errors:
+          - {label: unc, value: 0.02404}
+          - {label: add, value: 0.04672}
+        value: 0.54112
+      - errors:
+          - {label: unc, value: 0.01547}
+          - {label: add, value: 0.05114}
+        value: 0.26485
+      - errors:
+          - {label: unc, value: 0.01203}
+          - {label: add, value: 0.05955}
+        value: 0.20501
+      - errors:
+          - {label: unc, value: 0.01009}
+          - {label: add, value: 0.06607}
+        value: 0.16105
+      - errors:
+          - {label: unc, value: 0.0091}
+          - {label: add, value: 0.08824}
+        value: 0.11659
+      - errors:
+          - {label: unc, value: 0.00839}
+          - {label: add, value: 0.13101}
+        value: 0.08091
+      - errors:
+          - {label: unc, value: 0.01732}
+          - {label: add, value: 0.04489}
+        value: 0.43874
+      - errors:
+          - {label: unc, value: 0.01305}
+          - {label: add, value: 0.04713}
+        value: 0.32489
+      - errors:
+          - {label: unc, value: 0.01067}
+          - {label: add, value: 0.05053}
+        value: 0.24698
+      - errors:
+          - {label: unc, value: 0.00903}
+          - {label: add, value: 0.05583}
+        value: 0.18873
+      - errors:
+          - {label: unc, value: 0.00835}
+          - {label: add, value: 0.065}
+        value: 0.15212
+      - errors:
+          - {label: unc, value: 0.00762}
+          - {label: add, value: 0.08036}
+        value: 0.11459
+      - errors:
+          - {label: unc, value: 0.00746}
+          - {label: add, value: 0.12307}
+        value: 0.07859
+      - errors:
+          - {label: unc, value: 0.0381}
+          - {label: add, value: 0.04281}
+        value: 1.05574
+      - errors:
+          - {label: unc, value: 0.02702}
+          - {label: add, value: 0.04313}
+        value: 0.77217
+      - errors:
+          - {label: unc, value: 0.01947}
+          - {label: add, value: 0.04355}
+        value: 0.54945
+      - errors:
+          - {label: unc, value: 0.01524}
+          - {label: add, value: 0.04423}
+        value: 0.41506
+      - errors:
+          - {label: unc, value: 0.01237}
+          - {label: add, value: 0.04542}
+        value: 0.32196
+      - errors:
+          - {label: unc, value: 0.00995}
+          - {label: add, value: 0.04708}
+        value: 0.24416
+      - errors:
+          - {label: unc, value: 0.00804}
+          - {label: add, value: 0.05088}
+        value: 0.18065
+      - errors:
+          - {label: unc, value: 0.00733}
+          - {label: add, value: 0.05776}
+        value: 0.14654
+      - errors:
+          - {label: unc, value: 0.00652}
+          - {label: add, value: 0.0698}
+        value: 0.10968
+      - errors:
+          - {label: unc, value: 0.00611}
+          - {label: add, value: 0.10873}
+        value: 0.07203
+      - errors:
+          - {label: unc, value: 0.07529}
+          - {label: add, value: 0.04292}
+        value: 2.18867
+      - errors:
+          - {label: unc, value: 0.04958}
+          - {label: add, value: 0.04276}
+        value: 1.47225
+      - errors:
+          - {label: unc, value: 0.03577}
+          - {label: add, value: 0.04292}
+        value: 1.0425
+      - errors:
+          - {label: unc, value: 0.02591}
+          - {label: add, value: 0.04326}
+        value: 0.73192
+      - errors:
+          - {label: unc, value: 0.01986}
+          - {label: add, value: 0.04356}
+        value: 0.54269
+      - errors:
+          - {label: unc, value: 0.01481}
+          - {label: add, value: 0.04415}
+        value: 0.38545
+      - errors:
+          - {label: unc, value: 0.01203}
+          - {label: add, value: 0.04498}
+        value: 0.29186
+      - errors:
+          - {label: unc, value: 0.01013}
+          - {label: add, value: 0.04625}
+        value: 0.22243
+      - errors:
+          - {label: unc, value: 0.00913}
+          - {label: add, value: 0.04895}
+        value: 0.17551
+      - errors:
+          - {label: unc, value: 0.00841}
+          - {label: add, value: 0.05453}
+        value: 0.13497
+      - errors:
+          - {label: unc, value: 0.00803}
+          - {label: add, value: 0.0712}
+        value: 0.09416
+      - errors:
+          - {label: unc, value: 0.0779}
+          - {label: add, value: 0.04484}
+        value: 2.12033
+      - errors:
+          - {label: unc, value: 0.05481}
+          - {label: add, value: 0.0451}
+        value: 1.42632
+      - errors:
+          - {label: unc, value: 0.04146}
+          - {label: add, value: 0.04538}
+        value: 1.0268
+      - errors:
+          - {label: unc, value: 0.03203}
+          - {label: add, value: 0.04547}
+        value: 0.71214
+      - errors:
+          - {label: unc, value: 0.02962}
+          - {label: add, value: 0.04575}
+        value: 0.51831
+      - errors:
+          - {label: unc, value: 0.01546}
+          - {label: add, value: 0.04857}
+        value: 0.2647
+      - errors:
+          - {label: unc, value: 0.0111}
+          - {label: add, value: 0.05062}
+        value: 0.2159
+      - errors:
+          - {label: unc, value: 0.00854}
+          - {label: add, value: 0.05944}
+        value: 0.156
+      - errors:
+          - {label: unc, value: 0.00785}
+          - {label: add, value: 0.07268}
+        value: 0.12603
+      - errors:
+          - {label: unc, value: 0.0074}
+          - {label: add, value: 0.10613}
+        value: 0.08955
+      - errors:
+          - {label: unc, value: 0.01812}
+          - {label: add, value: 0.04399}
+        value: 0.41467
+      - errors:
+          - {label: unc, value: 0.01299}
+          - {label: add, value: 0.04515}
+        value: 0.30461
+      - errors:
+          - {label: unc, value: 0.01092}
+          - {label: add, value: 0.04639}
+        value: 0.24644
+      - errors:
+          - {label: unc, value: 0.00891}
+          - {label: add, value: 0.04938}
+        value: 0.18453
+      - errors:
+          - {label: unc, value: 0.00828}
+          - {label: add, value: 0.05468}
+        value: 0.15683
+      - errors:
+          - {label: unc, value: 0.00726}
+          - {label: add, value: 0.06086}
+        value: 0.12421
+      - errors:
+          - {label: unc, value: 0.00615}
+          - {label: add, value: 0.08986}
+        value: 0.0836
+      - errors:
+          - {label: unc, value: 0.04057}
+          - {label: add, value: 0.04216}
+        value: 1.03948
+      - errors:
+          - {label: unc, value: 0.02807}
+          - {label: add, value: 0.04259}
+        value: 0.76122
+      - errors:
+          - {label: unc, value: 0.02096}
+          - {label: add, value: 0.04285}
+        value: 0.56273
+      - errors:
+          - {label: unc, value: 0.01545}
+          - {label: add, value: 0.04332}
+        value: 0.39332
+      - errors:
+          - {label: unc, value: 0.01247}
+          - {label: add, value: 0.04383}
+        value: 0.30081
+      - errors:
+          - {label: unc, value: 0.00994}
+          - {label: add, value: 0.04527}
+        value: 0.22284
+      - errors:
+          - {label: unc, value: 0.00857}
+          - {label: add, value: 0.04696}
+        value: 0.18024
+      - errors:
+          - {label: unc, value: 0.00759}
+          - {label: add, value: 0.05088}
+        value: 0.14592
+      - errors:
+          - {label: unc, value: 0.0062}
+          - {label: add, value: 0.06193}
+        value: 0.10114
+      - errors:
+          - {label: unc, value: 0.00501}
+          - {label: add, value: 0.07719}
+        value: 0.07504
+      - errors:
+          - {label: unc, value: 0.07956}
+          - {label: add, value: 0.04267}
+        value: 2.20011
+      - errors:
+          - {label: unc, value: 0.05251}
+          - {label: add, value: 0.04256}
+        value: 1.50425
+      - errors:
+          - {label: unc, value: 0.03745}
+          - {label: add, value: 0.04274}
+        value: 1.03913
+      - errors:
+          - {label: unc, value: 0.02793}
+          - {label: add, value: 0.04297}
+        value: 0.74154
+      - errors:
+          - {label: unc, value: 0.02171}
+          - {label: add, value: 0.04336}
+        value: 0.54792
+      - errors:
+          - {label: unc, value: 0.01685}
+          - {label: add, value: 0.04376}
+        value: 0.39855
+      - errors:
+          - {label: unc, value: 0.01388}
+          - {label: add, value: 0.04452}
+        value: 0.29864
+      - errors:
+          - {label: unc, value: 0.01139}
+          - {label: add, value: 0.04561}
+        value: 0.21242
+      - errors:
+          - {label: unc, value: 0.01148}
+          - {label: add, value: 0.04701}
+        value: 0.18907
+      - errors:
+          - {label: unc, value: 0.01102}
+          - {label: add, value: 0.05015}
+        value: 0.14723
+      - errors:
+          - {label: unc, value: 0.01066}
+          - {label: add, value: 0.05226}
+        value: 0.10777
+      - errors:
+          - {label: unc, value: 0.08878}
+          - {label: add, value: 0.0441}
+        value: 2.24196
+      - errors:
+          - {label: unc, value: 0.06459}
+          - {label: add, value: 0.0443}
+        value: 1.51886
+      - errors:
+          - {label: unc, value: 0.04642}
+          - {label: add, value: 0.04463}
+        value: 0.99253
+      - errors:
+          - {label: unc, value: 0.04096}
+          - {label: add, value: 0.04495}
+        value: 0.76611
+      - errors:
+          - {label: unc, value: 0.03873}
+          - {label: add, value: 0.04562}
+        value: 0.51123
+      - errors:
+          - {label: unc, value: 0.01001}
+          - {label: add, value: 0.04644}
+        value: 0.19984
+      - errors:
+          - {label: unc, value: 0.00764}
+          - {label: add, value: 0.0501}
+        value: 0.15362
+      - errors:
+          - {label: unc, value: 0.00644}
+          - {label: add, value: 0.05835}
+        value: 0.12024
+      - errors:
+          - {label: unc, value: 0.00583}
+          - {label: add, value: 0.0808}
+        value: 0.09059
+      - errors:
+          - {label: unc, value: 0.01786}
+          - {label: add, value: 0.04274}
+        value: 0.41628
+      - errors:
+          - {label: unc, value: 0.01309}
+          - {label: add, value: 0.04329}
+        value: 0.31819
+      - errors:
+          - {label: unc, value: 0.01051}
+          - {label: add, value: 0.04425}
+        value: 0.24442
+      - errors:
+          - {label: unc, value: 0.0087}
+          - {label: add, value: 0.04576}
+        value: 0.18898
+      - errors:
+          - {label: unc, value: 0.00738}
+          - {label: add, value: 0.0485}
+        value: 0.14828
+      - errors:
+          - {label: unc, value: 0.00652}
+          - {label: add, value: 0.05348}
+        value: 0.11922
+      - errors:
+          - {label: unc, value: 0.00474}
+          - {label: add, value: 0.07138}
+        value: 0.07677
+      - errors:
+          - {label: unc, value: 0.04195}
+          - {label: add, value: 0.04233}
+        value: 1.07802
+      - errors:
+          - {label: unc, value: 0.02776}
+          - {label: add, value: 0.04238}
+        value: 0.7545
+      - errors:
+          - {label: unc, value: 0.01983}
+          - {label: add, value: 0.04259}
+        value: 0.53328
+      - errors:
+          - {label: unc, value: 0.01569}
+          - {label: add, value: 0.04289}
+        value: 0.40436
+      - errors:
+          - {label: unc, value: 0.0123}
+          - {label: add, value: 0.04332}
+        value: 0.30048
+      - errors:
+          - {label: unc, value: 0.01009}
+          - {label: add, value: 0.04387}
+        value: 0.23287
+      - errors:
+          - {label: unc, value: 0.00853}
+          - {label: add, value: 0.04504}
+        value: 0.18455
+      - errors:
+          - {label: unc, value: 0.00707}
+          - {label: add, value: 0.04705}
+        value: 0.14146
+      - errors:
+          - {label: unc, value: 0.00575}
+          - {label: add, value: 0.05016}
+        value: 0.10366
+      - errors:
+          - {label: unc, value: 0.00426}
+          - {label: add, value: 0.06379}
+        value: 0.07261
+      - errors:
+          - {label: unc, value: 0.08111}
+          - {label: add, value: 0.04255}
+        value: 2.23505
+      - errors:
+          - {label: unc, value: 0.05284}
+          - {label: add, value: 0.0423}
+        value: 1.52175
+      - errors:
+          - {label: unc, value: 0.03708}
+          - {label: add, value: 0.04247}
+        value: 1.03376
+      - errors:
+          - {label: unc, value: 0.02758}
+          - {label: add, value: 0.04271}
+        value: 0.73607
+      - errors:
+          - {label: unc, value: 0.02208}
+          - {label: add, value: 0.04303}
+        value: 0.56224
+      - errors:
+          - {label: unc, value: 0.01634}
+          - {label: add, value: 0.04356}
+        value: 0.3855
+      - errors:
+          - {label: unc, value: 0.01317}
+          - {label: add, value: 0.04387}
+        value: 0.28232
+      - errors:
+          - {label: unc, value: 0.01225}
+          - {label: add, value: 0.04493}
+        value: 0.23644
+      - errors:
+          - {label: unc, value: 0.01115}
+          - {label: add, value: 0.04573}
+        value: 0.18703
+      - errors:
+          - {label: unc, value: 0.01016}
+          - {label: add, value: 0.04597}
+        value: 0.13662
+      - errors:
+          - {label: unc, value: 0.0097}
+          - {label: add, value: 0.05011}
+        value: 0.09578
+      - errors:
+          - {label: unc, value: 0.08676}
+          - {label: add, value: 0.04293}
+        value: 2.15034
+      - errors:
+          - {label: unc, value: 0.06385}
+          - {label: add, value: 0.04323}
+        value: 1.44343
+      - errors:
+          - {label: unc, value: 0.05209}
+          - {label: add, value: 0.04344}
+        value: 1.09109
+      - errors:
+          - {label: unc, value: 0.03903}
+          - {label: add, value: 0.0443}
+        value: 0.66595
+      - errors:
+          - {label: unc, value: 0.04088}
+          - {label: add, value: 0.04501}
+        value: 0.51223
+      - errors:
+          - {label: unc, value: 0.01032}
+          - {label: add, value: 0.0445}
+        value: 0.18913
+      - errors:
+          - {label: unc, value: 0.00782}
+          - {label: add, value: 0.04549}
+        value: 0.15054
+      - errors:
+          - {label: unc, value: 0.00595}
+          - {label: add, value: 0.04858}
+        value: 0.11265
+      - errors:
+          - {label: unc, value: 0.00454}
+          - {label: add, value: 0.05891}
+        value: 0.08719
+      - errors:
+          - {label: unc, value: 0.01857}
+          - {label: add, value: 0.04231}
+        value: 0.40178
+      - errors:
+          - {label: unc, value: 0.01352}
+          - {label: add, value: 0.04276}
+        value: 0.30853
+      - errors:
+          - {label: unc, value: 0.01073}
+          - {label: add, value: 0.04314}
+        value: 0.23424
+      - errors:
+          - {label: unc, value: 0.00898}
+          - {label: add, value: 0.04382}
+        value: 0.18439
+      - errors:
+          - {label: unc, value: 0.00745}
+          - {label: add, value: 0.04516}
+        value: 0.14155
+      - errors:
+          - {label: unc, value: 0.00634}
+          - {label: add, value: 0.04679}
+        value: 0.11182
+      - errors:
+          - {label: unc, value: 0.0044}
+          - {label: add, value: 0.05406}
+        value: 0.0808
+      - errors:
+          - {label: unc, value: 0.04313}
+          - {label: add, value: 0.04173}
+        value: 1.07017
+      - errors:
+          - {label: unc, value: 0.02836}
+          - {label: add, value: 0.04176}
+        value: 0.75514
+      - errors:
+          - {label: unc, value: 0.02081}
+          - {label: add, value: 0.04197}
+        value: 0.5486
+      - errors:
+          - {label: unc, value: 0.01627}
+          - {label: add, value: 0.04218}
+        value: 0.40795
+      - errors:
+          - {label: unc, value: 0.01241}
+          - {label: add, value: 0.04238}
+        value: 0.29222
+      - errors:
+          - {label: unc, value: 0.01033}
+          - {label: add, value: 0.0426}
+        value: 0.23002
+      - errors:
+          - {label: unc, value: 0.00843}
+          - {label: add, value: 0.04324}
+        value: 0.17189
+      - errors:
+          - {label: unc, value: 0.00749}
+          - {label: add, value: 0.04441}
+        value: 0.14412
+      - errors:
+          - {label: unc, value: 0.00609}
+          - {label: add, value: 0.04638}
+        value: 0.10607
+      - errors:
+          - {label: unc, value: 0.00394}
+          - {label: add, value: 0.05188}
+        value: 0.07063
+      - errors:
+          - {label: unc, value: 0.08661}
+          - {label: add, value: 0.04187}
+        value: 2.26929
+      - errors:
+          - {label: unc, value: 0.05394}
+          - {label: add, value: 0.0419}
+        value: 1.50745
+      - errors:
+          - {label: unc, value: 0.03948}
+          - {label: add, value: 0.04208}
+        value: 1.06292
+      - errors:
+          - {label: unc, value: 0.02905}
+          - {label: add, value: 0.04229}
+        value: 0.73698
+      - errors:
+          - {label: unc, value: 0.02394}
+          - {label: add, value: 0.04262}
+        value: 0.57703
+      - errors:
+          - {label: unc, value: 0.01787}
+          - {label: add, value: 0.04302}
+        value: 0.39483
+      - errors:
+          - {label: unc, value: 0.01462}
+          - {label: add, value: 0.04475}
+        value: 0.28529
+      - errors:
+          - {label: unc, value: 0.01362}
+          - {label: add, value: 0.04474}
+        value: 0.2382
+      - errors:
+          - {label: unc, value: 0.01159}
+          - {label: add, value: 0.04677}
+        value: 0.16625
+      - errors:
+          - {label: unc, value: 0.01109}
+          - {label: add, value: 0.04656}
+        value: 0.13058
+      - errors:
+          - {label: unc, value: 0.01206}
+          - {label: add, value: 0.04962}
+        value: 0.10721
+      - errors:
+          - {label: unc, value: 0.09901}
+          - {label: add, value: 0.04246}
+        value: 2.14988
+      - errors:
+          - {label: unc, value: 0.07358}
+          - {label: add, value: 0.0427}
+        value: 1.42132
+      - errors:
+          - {label: unc, value: 0.06105}
+          - {label: add, value: 0.04338}
+        value: 1.05572
+      - errors:
+          - {label: unc, value: 0.05589}
+          - {label: add, value: 0.04516}
+        value: 0.79065
+      - errors:
+          - {label: unc, value: 0.0526}
+          - {label: add, value: 0.04463}
+        value: 0.50015
+      - errors:
+          - {label: unc, value: 0.01532}
+          - {label: add, value: 0.04396}
+        value: 0.17926
+      - errors:
+          - {label: unc, value: 0.01146}
+          - {label: add, value: 0.04447}
+        value: 0.14573
+      - errors:
+          - {label: unc, value: 0.00956}
+          - {label: add, value: 0.04464}
+        value: 0.12456
+      - errors:
+          - {label: unc, value: 0.00557}
+          - {label: add, value: 0.04788}
+        value: 0.08906
+      - errors:
+          - {label: unc, value: 0.02398}
+          - {label: add, value: 0.04194}
+        value: 0.36856
+      - errors:
+          - {label: unc, value: 0.01893}
+          - {label: add, value: 0.04213}
+        value: 0.32525
+      - errors:
+          - {label: unc, value: 0.01365}
+          - {label: add, value: 0.04217}
+        value: 0.21058
+      - errors:
+          - {label: unc, value: 0.01212}
+          - {label: add, value: 0.04345}
+        value: 0.17122
+      - errors:
+          - {label: unc, value: 0.01068}
+          - {label: add, value: 0.04296}
+        value: 0.13966
+      - errors:
+          - {label: unc, value: 0.00975}
+          - {label: add, value: 0.04396}
+        value: 0.11994
+      - errors:
+          - {label: unc, value: 0.00536}
+          - {label: add, value: 0.04687}
+        value: 0.07357
+      - errors:
+          - {label: unc, value: 0.05791}
+          - {label: add, value: 0.04117}
+        value: 1.09664
+      - errors:
+          - {label: unc, value: 0.0341}
+          - {label: add, value: 0.04126}
+        value: 0.73517
+      - errors:
+          - {label: unc, value: 0.02513}
+          - {label: add, value: 0.04134}
+        value: 0.53784
+      - errors:
+          - {label: unc, value: 0.02082}
+          - {label: add, value: 0.0414}
+        value: 0.41123
+      - errors:
+          - {label: unc, value: 0.01658}
+          - {label: add, value: 0.04155}
+        value: 0.29749
+      - errors:
+          - {label: unc, value: 0.01406}
+          - {label: add, value: 0.04191}
+        value: 0.23171
+      - errors:
+          - {label: unc, value: 0.01148}
+          - {label: add, value: 0.04291}
+        value: 0.16947
+      - errors:
+          - {label: unc, value: 0.01009}
+          - {label: add, value: 0.04339}
+        value: 0.13495
+      - errors:
+          - {label: unc, value: 0.00803}
+          - {label: add, value: 0.04344}
+        value: 0.09301
+      - errors:
+          - {label: unc, value: 0.00484}
+          - {label: add, value: 0.04702}
+        value: 0.06363
+      - errors:
+          - {label: unc, value: 0.1174}
+          - {label: add, value: 0.04135}
+        value: 2.29929
+      - errors:
+          - {label: unc, value: 0.0663}
+          - {label: add, value: 0.04119}
+        value: 1.52023
+      - errors:
+          - {label: unc, value: 0.04949}
+          - {label: add, value: 0.04131}
+        value: 1.0515
+      - errors:
+          - {label: unc, value: 0.03767}
+          - {label: add, value: 0.0416}
+        value: 0.71489
+      - errors:
+          - {label: unc, value: 0.03208}
+          - {label: add, value: 0.04154}
+        value: 0.55771
+      - errors:
+          - {label: unc, value: 0.02593}
+          - {label: add, value: 0.04349}
+        value: 0.39163
+      - errors:
+          - {label: unc, value: 0.02207}
+          - {label: add, value: 0.04343}
+        value: 0.29272
+      - errors:
+          - {label: unc, value: 0.01889}
+          - {label: add, value: 0.04501}
+        value: 0.20619
+      - errors:
+          - {label: unc, value: 0.01858}
+          - {label: add, value: 0.05229}
+        value: 0.16431
+      - errors:
+          - {label: unc, value: 0.0174}
+          - {label: add, value: 0.06207}
+        value: 0.12103
+      - errors:
+          - {label: unc, value: 0.01779}
+          - {label: add, value: 0.06229}
+        value: 0.08733
+      - errors:
+          - {label: unc, value: 0.16015}
+          - {label: add, value: 0.04195}
+        value: 2.26178
+      - errors:
+          - {label: unc, value: 0.13576}
+          - {label: add, value: 0.0423}
+        value: 1.69585
+      - errors:
+          - {label: unc, value: 0.11257}
+          - {label: add, value: 0.0426}
+        value: 1.2181
+      - errors:
+          - {label: unc, value: 0.08315}
+          - {label: add, value: 0.04809}
+        value: 0.63849
+      - errors:
+          - {label: unc, value: 0.08697}
+          - {label: add, value: 0.05022}
+        value: 0.45706
+      - errors:
+          - {label: unc, value: 0.02845}
+          - {label: add, value: 0.04188}
+        value: 0.24433
+      - errors:
+          - {label: unc, value: 0.01963}
+          - {label: add, value: 0.04323}
+        value: 0.15915
+      - errors:
+          - {label: unc, value: 0.01378}
+          - {label: add, value: 0.04315}
+        value: 0.10846
+      - errors:
+          - {label: unc, value: 0.00802}
+          - {label: add, value: 0.04486}
+        value: 0.08097
+      - errors:
+          - {label: unc, value: 0.03873}
+          - {label: add, value: 0.04255}
+        value: 0.43356
+      - errors:
+          - {label: unc, value: 0.02668}
+          - {label: add, value: 0.04285}
+        value: 0.31461
+      - errors:
+          - {label: unc, value: 0.02045}
+          - {label: add, value: 0.04185}
+        value: 0.22287
+      - errors:
+          - {label: unc, value: 0.01745}
+          - {label: add, value: 0.0452}
+        value: 0.16336
+      - errors:
+          - {label: unc, value: 0.01428}
+          - {label: add, value: 0.04265}
+        value: 0.11687
+      - errors:
+          - {label: unc, value: 0.0135}
+          - {label: add, value: 0.04316}
+        value: 0.11028
+      - errors:
+          - {label: unc, value: 0.00803}
+          - {label: add, value: 0.04403}
+        value: 0.07467
+      - errors:
+          - {label: unc, value: 0.07413}
+          - {label: add, value: 0.04122}
+        value: 0.96319
+      - errors:
+          - {label: unc, value: 0.04547}
+          - {label: add, value: 0.04155}
+        value: 0.71473
+      - errors:
+          - {label: unc, value: 0.03234}
+          - {label: add, value: 0.04189}
+        value: 0.50279
+      - errors:
+          - {label: unc, value: 0.02707}
+          - {label: add, value: 0.04194}
+        value: 0.38076
+      - errors:
+          - {label: unc, value: 0.0246}
+          - {label: add, value: 0.04176}
+        value: 0.3207
+      - errors:
+          - {label: unc, value: 0.02013}
+          - {label: add, value: 0.04241}
+        value: 0.22978
+      - errors:
+          - {label: unc, value: 0.01621}
+          - {label: add, value: 0.04457}
+        value: 0.16459
+      - errors:
+          - {label: unc, value: 0.01632}
+          - {label: add, value: 0.04245}
+        value: 0.16282
+      - errors:
+          - {label: unc, value: 0.01049}
+          - {label: add, value: 0.04864}
+        value: 0.07846
+      - errors:
+          - {label: unc, value: 0.00696}
+          - {label: add, value: 0.05171}
+        value: 0.06158
+      - errors:
+          - {label: unc, value: 0.1733}
+          - {label: add, value: 0.04142}
+        value: 2.45469
+      - errors:
+          - {label: unc, value: 0.08742}
+          - {label: add, value: 0.04148}
+        value: 1.47688
+      - errors:
+          - {label: unc, value: 0.07006}
+          - {label: add, value: 0.04124}
+        value: 1.09292
+      - errors:
+          - {label: unc, value: 0.05668}
+          - {label: add, value: 0.0418}
+        value: 0.77338
+      - errors:
+          - {label: unc, value: 0.04652}
+          - {label: add, value: 0.04219}
+        value: 0.54946
+      - errors:
+          - {label: unc, value: 0.04017}
+          - {label: add, value: 0.04212}
+        value: 0.42892
+      - errors:
+          - {label: unc, value: 0.03709}
+          - {label: add, value: 0.04282}
+        value: 0.34361
+      - errors:
+          - {label: unc, value: 0.02816}
+          - {label: add, value: 0.05354}
+        value: 0.19038
+      - errors:
+          - {label: unc, value: 0.03068}
+          - {label: add, value: 0.05176}
+        value: 0.17912
+      - errors:
+          - {label: unc, value: 0.02716}
+          - {label: add, value: 0.06666}
+        value: 0.11533
+      - errors:
+          - {label: unc, value: 0.25783}
+          - {label: add, value: 0.04203}
+        value: 2.4567
+      - errors:
+          - {label: unc, value: 0.20346}
+          - {label: add, value: 0.04265}
+        value: 1.50686
+      - errors:
+          - {label: unc, value: 0.1686}
+          - {label: add, value: 0.04351}
+        value: 1.0721
+      - errors:
+          - {label: unc, value: 0.16995}
+          - {label: add, value: 0.04535}
+        value: 0.91407
+      - errors:
+          - {label: unc, value: 0.04253}
+          - {label: add, value: 0.04132}
+        value: 0.44997
+      - errors:
+          - {label: unc, value: 0.02549}
+          - {label: add, value: 0.04168}
+        value: 0.26677
+      - errors:
+          - {label: unc, value: 0.02106}
+          - {label: add, value: 0.04183}
+        value: 0.19892
+      - errors:
+          - {label: unc, value: 0.02006}
+          - {label: add, value: 0.04188}
+        value: 0.17841
+      - errors:
+          - {label: unc, value: 0.018}
+          - {label: add, value: 0.04207}
+        value: 0.14831
+      - errors:
+          - {label: unc, value: 0.01657}
+          - {label: add, value: 0.04218}
+        value: 0.11987
+      - errors:
+          - {label: unc, value: 0.01077}
+          - {label: add, value: 0.04257}
+        value: 0.09923
+      - errors:
+          - {label: unc, value: 0.08645}
+          - {label: add, value: 0.04103}
+        value: 1.16183
+      - errors:
+          - {label: unc, value: 0.04732}
+          - {label: add, value: 0.04114}
+        value: 0.74624
+      - errors:
+          - {label: unc, value: 0.03651}
+          - {label: add, value: 0.04314}
+        value: 0.55452
+      - errors:
+          - {label: unc, value: 0.02542}
+          - {label: add, value: 0.04258}
+        value: 0.32913
+      - errors:
+          - {label: unc, value: 0.02505}
+          - {label: add, value: 0.04138}
+        value: 0.31379
+      - errors:
+          - {label: unc, value: 0.02123}
+          - {label: add, value: 0.04181}
+        value: 0.23478
+      - errors:
+          - {label: unc, value: 0.0179}
+          - {label: add, value: 0.04217}
+        value: 0.18516
+      - errors:
+          - {label: unc, value: 0.01584}
+          - {label: add, value: 0.0441}
+        value: 0.1424
+      - errors:
+          - {label: unc, value: 0.01259}
+          - {label: add, value: 0.04484}
+        value: 0.10009
+      - errors:
+          - {label: unc, value: 0.00728}
+          - {label: add, value: 0.0461}
+        value: 0.06403
+      - errors:
+          - {label: unc, value: 0.16247}
+          - {label: add, value: 0.04212}
+        value: 2.2469
+      - errors:
+          - {label: unc, value: 0.0914}
+          - {label: add, value: 0.04097}
+        value: 1.58658
+      - errors:
+          - {label: unc, value: 0.06432}
+          - {label: add, value: 0.04114}
+        value: 0.99351
+      - errors:
+          - {label: unc, value: 0.05793}
+          - {label: add, value: 0.04139}
+        value: 0.83168
+      - errors:
+          - {label: unc, value: 0.05031}
+          - {label: add, value: 0.0413}
+        value: 0.65784
+      - errors:
+          - {label: unc, value: 0.03984}
+          - {label: add, value: 0.04345}
+        value: 0.43983
+      - errors:
+          - {label: unc, value: 0.03314}
+          - {label: add, value: 0.04464}
+        value: 0.2891
+      - errors:
+          - {label: unc, value: 0.02765}
+          - {label: add, value: 0.0504}
+        value: 0.20001
+      - errors:
+          - {label: unc, value: 0.02635}
+          - {label: add, value: 0.04919}
+        value: 0.16263
+      - errors:
+          - {label: unc, value: 0.02606}
+          - {label: add, value: 0.04628}
+        value: 0.12827
+      - errors:
+          - {label: unc, value: 0.02627}
+          - {label: add, value: 0.0667}
+        value: 0.07508
+      - errors:
+          - {label: unc, value: 0.38525}
+          - {label: add, value: 0.04303}
+        value: 2.65275
+      - errors:
+          - {label: unc, value: 0.24115}
+          - {label: add, value: 0.04151}
+        value: 1.25274
+      - errors:
+          - {label: unc, value: 0.21913}
+          - {label: add, value: 0.04128}
+        value: 0.99734
+      - errors:
+          - {label: unc, value: 0.22125}
+          - {label: add, value: 0.05388}
+        value: 0.82175
+      - errors:
+          - {label: unc, value: 0.14942}
+          - {label: add, value: 0.04643}
+        value: 0.35595
+independent_variables:
+  - header: {name: z}
+    values:
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+  - header: {name: x}
+    values:
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+  - header: {name: y}
+    values:
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+  - header: {name: Q2}
+    values:
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 28.89816}
+      - {value: 28.89816}
+      - {value: 28.89816}
+      - {value: 28.89816}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 52.377915}
+      - {value: 52.377915}
+      - {value: 52.377915}
+      - {value: 52.377915}
+      - {value: 52.377915}

--- a/data/COMPASS_PI_PLUS_2026.yaml
+++ b/data/COMPASS_PI_PLUS_2026.yaml
@@ -1,0 +1,2472 @@
+dependent_variables:
+  - header: {title: COMPASS $pi^+$ Multiplicities}
+    qualifiers:
+      - {name: process, value: SIDIS}
+      - {name: observable, value: dsigma/dxdydz}
+      - {name: target_isoscalarity, value: 0.5}
+      - {name: prefactor, value: 1}
+      - {name: Vs, value: 17.35}
+      - {name: Q, low: 0.9, high: 6.0, integrate: true}
+      - {name: x, low: 0.004, high: 0.4, integrate: true}
+      - {name: z, low: 0.2, high: 0.85, integrate: true}
+      - {name: PS_reduction, W: 5, ymin: 0.1, ymax: 0.7}
+      - {name: hadron, value: PI}
+      - {name: charge, value: 1}
+    values:
+      - errors:
+          - {label: unc, value: 0.0573}
+          - {label: add, value: 0.03708}
+        value: 1.9699
+      - errors:
+          - {label: unc, value: 0.03933}
+          - {label: add, value: 0.0369}
+        value: 1.3332
+      - errors:
+          - {label: unc, value: 0.0299}
+          - {label: add, value: 0.03673}
+        value: 0.9911
+      - errors:
+          - {label: unc, value: 0.02168}
+          - {label: add, value: 0.03676}
+        value: 0.6898
+      - errors:
+          - {label: unc, value: 0.01689}
+          - {label: add, value: 0.03693}
+        value: 0.5112
+      - errors:
+          - {label: unc, value: 0.0142}
+          - {label: add, value: 0.03795}
+        value: 0.3942
+      - errors:
+          - {label: unc, value: 0.01304}
+          - {label: add, value: 0.04014}
+        value: 0.293
+      - errors:
+          - {label: unc, value: 0.01399}
+          - {label: add, value: 0.0399}
+        value: 0.2406
+      - errors:
+          - {label: unc, value: 0.01942}
+          - {label: add, value: 0.05211}
+        value: 0.2042
+      - errors:
+          - {label: unc, value: 0.02711}
+          - {label: add, value: 0.06954}
+        value: 0.1185
+      - errors:
+          - {label: unc, value: 0.05393}
+          - {label: add, value: 0.03659}
+        value: 1.9285
+      - errors:
+          - {label: unc, value: 0.03731}
+          - {label: add, value: 0.03635}
+        value: 1.3271
+      - errors:
+          - {label: unc, value: 0.02713}
+          - {label: add, value: 0.03634}
+        value: 0.9465
+      - errors:
+          - {label: unc, value: 0.02089}
+          - {label: add, value: 0.03654}
+        value: 0.6809
+      - errors:
+          - {label: unc, value: 0.01951}
+          - {label: add, value: 0.03675}
+        value: 0.5246
+      - errors:
+          - {label: unc, value: 0.0282}
+          - {label: add, value: 0.0377}
+        value: 0.5178
+      - errors:
+          - {label: unc, value: 0.02075}
+          - {label: add, value: 0.03741}
+        value: 0.4341
+      - errors:
+          - {label: unc, value: 0.0167}
+          - {label: add, value: 0.0379}
+        value: 0.3145
+      - errors:
+          - {label: unc, value: 0.01455}
+          - {label: add, value: 0.042}
+        value: 0.2362
+      - errors:
+          - {label: unc, value: 0.0135}
+          - {label: add, value: 0.05021}
+        value: 0.188
+      - errors:
+          - {label: unc, value: 0.01238}
+          - {label: add, value: 0.05012}
+        value: 0.1612
+      - errors:
+          - {label: unc, value: 0.01229}
+          - {label: add, value: 0.06224}
+        value: 0.1401
+      - errors:
+          - {label: unc, value: 0.0085}
+          - {label: add, value: 0.08085}
+        value: 0.094
+      - errors:
+          - {label: unc, value: 0.03021}
+          - {label: add, value: 0.03766}
+        value: 0.992
+      - errors:
+          - {label: unc, value: 0.02197}
+          - {label: add, value: 0.03747}
+        value: 0.7324
+      - errors:
+          - {label: unc, value: 0.01638}
+          - {label: add, value: 0.03748}
+        value: 0.5379
+      - errors:
+          - {label: unc, value: 0.01271}
+          - {label: add, value: 0.03756}
+        value: 0.4068
+      - errors:
+          - {label: unc, value: 0.01025}
+          - {label: add, value: 0.03831}
+        value: 0.3132
+      - errors:
+          - {label: unc, value: 0.00828}
+          - {label: add, value: 0.04032}
+        value: 0.2361
+      - errors:
+          - {label: unc, value: 0.00726}
+          - {label: add, value: 0.04115}
+        value: 0.1983
+      - errors:
+          - {label: unc, value: 0.00649}
+          - {label: add, value: 0.04642}
+        value: 0.1551
+      - errors:
+          - {label: unc, value: 0.00628}
+          - {label: add, value: 0.05519}
+        value: 0.129
+      - errors:
+          - {label: unc, value: 0.00529}
+          - {label: add, value: 0.07465}
+        value: 0.0868
+      - errors:
+          - {label: unc, value: 0.05631}
+          - {label: add, value: 0.03739}
+        value: 1.9705
+      - errors:
+          - {label: unc, value: 0.03929}
+          - {label: add, value: 0.03724}
+        value: 1.3833
+      - errors:
+          - {label: unc, value: 0.02752}
+          - {label: add, value: 0.03704}
+        value: 0.9676
+      - errors:
+          - {label: unc, value: 0.02012}
+          - {label: add, value: 0.03692}
+        value: 0.7021
+      - errors:
+          - {label: unc, value: 0.01506}
+          - {label: add, value: 0.03688}
+        value: 0.5185
+      - errors:
+          - {label: unc, value: 0.01129}
+          - {label: add, value: 0.03704}
+        value: 0.3801
+      - errors:
+          - {label: unc, value: 0.00911}
+          - {label: add, value: 0.0375}
+        value: 0.2944
+      - errors:
+          - {label: unc, value: 0.00777}
+          - {label: add, value: 0.03993}
+        value: 0.2244
+      - errors:
+          - {label: unc, value: 0.00697}
+          - {label: add, value: 0.04196}
+        value: 0.1792
+      - errors:
+          - {label: unc, value: 0.00669}
+          - {label: add, value: 0.04657}
+        value: 0.1443
+      - errors:
+          - {label: unc, value: 0.00681}
+          - {label: add, value: 0.05641}
+        value: 0.1092
+      - errors:
+          - {label: unc, value: 0.05423}
+          - {label: add, value: 0.03696}
+        value: 1.9201
+      - errors:
+          - {label: unc, value: 0.03722}
+          - {label: add, value: 0.03675}
+        value: 1.3103
+      - errors:
+          - {label: unc, value: 0.0265}
+          - {label: add, value: 0.03678}
+        value: 0.9157
+      - errors:
+          - {label: unc, value: 0.02009}
+          - {label: add, value: 0.03676}
+        value: 0.6638
+      - errors:
+          - {label: unc, value: 0.01674}
+          - {label: add, value: 0.03741}
+        value: 0.4704
+      - errors:
+          - {label: unc, value: 0.01392}
+          - {label: add, value: 0.04107}
+        value: 0.2591
+      - errors:
+          - {label: unc, value: 0.01122}
+          - {label: add, value: 0.04479}
+        value: 0.2179
+      - errors:
+          - {label: unc, value: 0.0095}
+          - {label: add, value: 0.04977}
+        value: 0.172
+      - errors:
+          - {label: unc, value: 0.00846}
+          - {label: add, value: 0.05337}
+        value: 0.1409
+      - errors:
+          - {label: unc, value: 0.00625}
+          - {label: add, value: 0.07344}
+        value: 0.0915
+      - errors:
+          - {label: unc, value: 0.02377}
+          - {label: add, value: 0.03783}
+        value: 0.5709
+      - errors:
+          - {label: unc, value: 0.01454}
+          - {label: add, value: 0.0379}
+        value: 0.42
+      - errors:
+          - {label: unc, value: 0.01112}
+          - {label: add, value: 0.03884}
+        value: 0.3213
+      - errors:
+          - {label: unc, value: 0.00927}
+          - {label: add, value: 0.03992}
+        value: 0.2565
+      - errors:
+          - {label: unc, value: 0.00811}
+          - {label: add, value: 0.04277}
+        value: 0.2039
+      - errors:
+          - {label: unc, value: 0.00724}
+          - {label: add, value: 0.04636}
+        value: 0.1674
+      - errors:
+          - {label: unc, value: 0.00636}
+          - {label: add, value: 0.05275}
+        value: 0.1289
+      - errors:
+          - {label: unc, value: 0.00543}
+          - {label: add, value: 0.07412}
+        value: 0.0885
+      - errors:
+          - {label: unc, value: 0.03168}
+          - {label: add, value: 0.03781}
+        value: 0.9987
+      - errors:
+          - {label: unc, value: 0.02234}
+          - {label: add, value: 0.03757}
+        value: 0.7303
+      - errors:
+          - {label: unc, value: 0.01684}
+          - {label: add, value: 0.03733}
+        value: 0.5486
+      - errors:
+          - {label: unc, value: 0.01273}
+          - {label: add, value: 0.03722}
+        value: 0.4041
+      - errors:
+          - {label: unc, value: 0.01029}
+          - {label: add, value: 0.03733}
+        value: 0.3172
+      - errors:
+          - {label: unc, value: 0.00814}
+          - {label: add, value: 0.03787}
+        value: 0.2366
+      - errors:
+          - {label: unc, value: 0.00698}
+          - {label: add, value: 0.03895}
+        value: 0.191
+      - errors:
+          - {label: unc, value: 0.00611}
+          - {label: add, value: 0.04181}
+        value: 0.155
+      - errors:
+          - {label: unc, value: 0.00563}
+          - {label: add, value: 0.04947}
+        value: 0.1229
+      - errors:
+          - {label: unc, value: 0.0047}
+          - {label: add, value: 0.06474}
+        value: 0.0865
+      - errors:
+          - {label: unc, value: 0.0584}
+          - {label: add, value: 0.03761}
+        value: 1.9933
+      - errors:
+          - {label: unc, value: 0.03986}
+          - {label: add, value: 0.03751}
+        value: 1.3735
+      - errors:
+          - {label: unc, value: 0.02816}
+          - {label: add, value: 0.03735}
+        value: 0.9616
+      - errors:
+          - {label: unc, value: 0.0207}
+          - {label: add, value: 0.03717}
+        value: 0.6974
+      - errors:
+          - {label: unc, value: 0.01524}
+          - {label: add, value: 0.03694}
+        value: 0.5025
+      - errors:
+          - {label: unc, value: 0.01154}
+          - {label: add, value: 0.03685}
+        value: 0.3691
+      - errors:
+          - {label: unc, value: 0.00937}
+          - {label: add, value: 0.03692}
+        value: 0.2817
+      - errors:
+          - {label: unc, value: 0.00797}
+          - {label: add, value: 0.0375}
+        value: 0.2176
+      - errors:
+          - {label: unc, value: 0.00712}
+          - {label: add, value: 0.03864}
+        value: 0.1677
+      - errors:
+          - {label: unc, value: 0.00632}
+          - {label: add, value: 0.0397}
+        value: 0.1209
+      - errors:
+          - {label: unc, value: 0.00711}
+          - {label: add, value: 0.04813}
+        value: 0.1014
+      - errors:
+          - {label: unc, value: 0.05753}
+          - {label: add, value: 0.03725}
+        value: 1.9627
+      - errors:
+          - {label: unc, value: 0.03981}
+          - {label: add, value: 0.03706}
+        value: 1.3296
+      - errors:
+          - {label: unc, value: 0.02904}
+          - {label: add, value: 0.0369}
+        value: 0.9365
+      - errors:
+          - {label: unc, value: 0.023}
+          - {label: add, value: 0.0377}
+        value: 0.6685
+      - errors:
+          - {label: unc, value: 0.02124}
+          - {label: add, value: 0.0374}
+        value: 0.4941
+      - errors:
+          - {label: unc, value: 0.01255}
+          - {label: add, value: 0.03814}
+        value: 0.2349
+      - errors:
+          - {label: unc, value: 0.00972}
+          - {label: add, value: 0.04086}
+        value: 0.2095
+      - errors:
+          - {label: unc, value: 0.00785}
+          - {label: add, value: 0.0437}
+        value: 0.1739
+      - errors:
+          - {label: unc, value: 0.00665}
+          - {label: add, value: 0.05142}
+        value: 0.1338
+      - errors:
+          - {label: unc, value: 0.00578}
+          - {label: add, value: 0.06866}
+        value: 0.1002
+      - errors:
+          - {label: unc, value: 0.0277}
+          - {label: add, value: 0.03803}
+        value: 0.5616
+      - errors:
+          - {label: unc, value: 0.01633}
+          - {label: add, value: 0.03789}
+        value: 0.4181
+      - errors:
+          - {label: unc, value: 0.01239}
+          - {label: add, value: 0.03761}
+        value: 0.3382
+      - errors:
+          - {label: unc, value: 0.00972}
+          - {label: add, value: 0.03805}
+        value: 0.2502
+      - errors:
+          - {label: unc, value: 0.00846}
+          - {label: add, value: 0.03901}
+        value: 0.2071
+      - errors:
+          - {label: unc, value: 0.00709}
+          - {label: add, value: 0.04208}
+        value: 0.1559
+      - errors:
+          - {label: unc, value: 0.00616}
+          - {label: add, value: 0.04594}
+        value: 0.1219
+      - errors:
+          - {label: unc, value: 0.00496}
+          - {label: add, value: 0.05807}
+        value: 0.0923
+      - errors:
+          - {label: unc, value: 0.03241}
+          - {label: add, value: 0.03808}
+        value: 0.9791
+      - errors:
+          - {label: unc, value: 0.02342}
+          - {label: add, value: 0.03795}
+        value: 0.7336
+      - errors:
+          - {label: unc, value: 0.01746}
+          - {label: add, value: 0.03782}
+        value: 0.5415
+      - errors:
+          - {label: unc, value: 0.01328}
+          - {label: add, value: 0.03768}
+        value: 0.3992
+      - errors:
+          - {label: unc, value: 0.01028}
+          - {label: add, value: 0.03732}
+        value: 0.2958
+      - errors:
+          - {label: unc, value: 0.00833}
+          - {label: add, value: 0.03769}
+        value: 0.2271
+      - errors:
+          - {label: unc, value: 0.00709}
+          - {label: add, value: 0.03797}
+        value: 0.1833
+      - errors:
+          - {label: unc, value: 0.00578}
+          - {label: add, value: 0.03962}
+        value: 0.1373
+      - errors:
+          - {label: unc, value: 0.00523}
+          - {label: add, value: 0.04344}
+        value: 0.1105
+      - errors:
+          - {label: unc, value: 0.00413}
+          - {label: add, value: 0.0547}
+        value: 0.0819
+      - errors:
+          - {label: unc, value: 0.06088}
+          - {label: add, value: 0.03805}
+        value: 2.0098
+      - errors:
+          - {label: unc, value: 0.04104}
+          - {label: add, value: 0.03801}
+        value: 1.3723
+      - errors:
+          - {label: unc, value: 0.02895}
+          - {label: add, value: 0.03776}
+        value: 0.9554
+      - errors:
+          - {label: unc, value: 0.02171}
+          - {label: add, value: 0.03763}
+        value: 0.7016
+      - errors:
+          - {label: unc, value: 0.01617}
+          - {label: add, value: 0.03735}
+        value: 0.5076
+      - errors:
+          - {label: unc, value: 0.01241}
+          - {label: add, value: 0.03732}
+        value: 0.3708
+      - errors:
+          - {label: unc, value: 0.01004}
+          - {label: add, value: 0.03775}
+        value: 0.2734
+      - errors:
+          - {label: unc, value: 0.00843}
+          - {label: add, value: 0.03733}
+        value: 0.2079
+      - errors:
+          - {label: unc, value: 0.00728}
+          - {label: add, value: 0.0384}
+        value: 0.1479
+      - errors:
+          - {label: unc, value: 0.00726}
+          - {label: add, value: 0.04349}
+        value: 0.1159
+      - errors:
+          - {label: unc, value: 0.00764}
+          - {label: add, value: 0.05498}
+        value: 0.0844
+      - errors:
+          - {label: unc, value: 0.05914}
+          - {label: add, value: 0.03762}
+        value: 1.9201
+      - errors:
+          - {label: unc, value: 0.04252}
+          - {label: add, value: 0.03749}
+        value: 1.3231
+      - errors:
+          - {label: unc, value: 0.03221}
+          - {label: add, value: 0.03734}
+        value: 0.9492
+      - errors:
+          - {label: unc, value: 0.02588}
+          - {label: add, value: 0.03737}
+        value: 0.6636
+      - errors:
+          - {label: unc, value: 0.02433}
+          - {label: add, value: 0.04032}
+        value: 0.4484
+      - errors:
+          - {label: unc, value: 0.01275}
+          - {label: add, value: 0.03885}
+        value: 0.2533
+      - errors:
+          - {label: unc, value: 0.00915}
+          - {label: add, value: 0.03934}
+        value: 0.2074
+      - errors:
+          - {label: unc, value: 0.00747}
+          - {label: add, value: 0.04233}
+        value: 0.172
+      - errors:
+          - {label: unc, value: 0.00584}
+          - {label: add, value: 0.04533}
+        value: 0.1306
+      - errors:
+          - {label: unc, value: 0.00469}
+          - {label: add, value: 0.05662}
+        value: 0.0975
+      - errors:
+          - {label: unc, value: 0.02431}
+          - {label: add, value: 0.03819}
+        value: 0.5425
+      - errors:
+          - {label: unc, value: 0.01516}
+          - {label: add, value: 0.0379}
+        value: 0.4158
+      - errors:
+          - {label: unc, value: 0.01127}
+          - {label: add, value: 0.03783}
+        value: 0.3193
+      - errors:
+          - {label: unc, value: 0.00884}
+          - {label: add, value: 0.03778}
+        value: 0.2414
+      - errors:
+          - {label: unc, value: 0.00729}
+          - {label: add, value: 0.03828}
+        value: 0.1881
+      - errors:
+          - {label: unc, value: 0.00625}
+          - {label: add, value: 0.03895}
+        value: 0.152
+      - errors:
+          - {label: unc, value: 0.00532}
+          - {label: add, value: 0.04186}
+        value: 0.1185
+      - errors:
+          - {label: unc, value: 0.00392}
+          - {label: add, value: 0.05192}
+        value: 0.0832
+      - errors:
+          - {label: unc, value: 0.03339}
+          - {label: add, value: 0.0384}
+        value: 1.0376
+      - errors:
+          - {label: unc, value: 0.02316}
+          - {label: add, value: 0.03838}
+        value: 0.74
+      - errors:
+          - {label: unc, value: 0.01684}
+          - {label: add, value: 0.03824}
+        value: 0.5356
+      - errors:
+          - {label: unc, value: 0.01294}
+          - {label: add, value: 0.0381}
+        value: 0.4011
+      - errors:
+          - {label: unc, value: 0.00993}
+          - {label: add, value: 0.03801}
+        value: 0.2968
+      - errors:
+          - {label: unc, value: 0.00784}
+          - {label: add, value: 0.03789}
+        value: 0.2259
+      - errors:
+          - {label: unc, value: 0.00618}
+          - {label: add, value: 0.03767}
+        value: 0.1699
+      - errors:
+          - {label: unc, value: 0.00513}
+          - {label: add, value: 0.03876}
+        value: 0.1321
+      - errors:
+          - {label: unc, value: 0.00448}
+          - {label: add, value: 0.04099}
+        value: 0.1054
+      - errors:
+          - {label: unc, value: 0.0032}
+          - {label: add, value: 0.04831}
+        value: 0.0712
+      - errors:
+          - {label: unc, value: 0.06119}
+          - {label: add, value: 0.03852}
+        value: 2.0166
+      - errors:
+          - {label: unc, value: 0.04182}
+          - {label: add, value: 0.03844}
+        value: 1.3965
+      - errors:
+          - {label: unc, value: 0.02935}
+          - {label: add, value: 0.0382}
+        value: 0.9717
+      - errors:
+          - {label: unc, value: 0.0211}
+          - {label: add, value: 0.03797}
+        value: 0.6869
+      - errors:
+          - {label: unc, value: 0.01623}
+          - {label: add, value: 0.03777}
+        value: 0.5168
+      - errors:
+          - {label: unc, value: 0.01189}
+          - {label: add, value: 0.03778}
+        value: 0.3621
+      - errors:
+          - {label: unc, value: 0.00971}
+          - {label: add, value: 0.03783}
+        value: 0.277
+      - errors:
+          - {label: unc, value: 0.00812}
+          - {label: add, value: 0.03769}
+        value: 0.208
+      - errors:
+          - {label: unc, value: 0.0068}
+          - {label: add, value: 0.03789}
+        value: 0.1499
+      - errors:
+          - {label: unc, value: 0.00656}
+          - {label: add, value: 0.03907}
+        value: 0.1167
+      - errors:
+          - {label: unc, value: 0.00727}
+          - {label: add, value: 0.04211}
+        value: 0.0969
+      - errors:
+          - {label: unc, value: 0.06094}
+          - {label: add, value: 0.03784}
+        value: 1.9473
+      - errors:
+          - {label: unc, value: 0.04379}
+          - {label: add, value: 0.03766}
+        value: 1.3426
+      - errors:
+          - {label: unc, value: 0.03289}
+          - {label: add, value: 0.03753}
+        value: 0.9486
+      - errors:
+          - {label: unc, value: 0.02677}
+          - {label: add, value: 0.03751}
+        value: 0.6739
+      - errors:
+          - {label: unc, value: 0.02638}
+          - {label: add, value: 0.03934}
+        value: 0.4982
+      - errors:
+          - {label: unc, value: 0.01146}
+          - {label: add, value: 0.03846}
+        value: 0.2371
+      - errors:
+          - {label: unc, value: 0.00792}
+          - {label: add, value: 0.0383}
+        value: 0.188
+      - errors:
+          - {label: unc, value: 0.00654}
+          - {label: add, value: 0.03948}
+        value: 0.1601
+      - errors:
+          - {label: unc, value: 0.0052}
+          - {label: add, value: 0.04126}
+        value: 0.1241
+      - errors:
+          - {label: unc, value: 0.00371}
+          - {label: add, value: 0.05012}
+        value: 0.0862
+      - errors:
+          - {label: unc, value: 0.02311}
+          - {label: add, value: 0.03888}
+        value: 0.5329
+      - errors:
+          - {label: unc, value: 0.0141}
+          - {label: add, value: 0.03845}
+        value: 0.3953
+      - errors:
+          - {label: unc, value: 0.01046}
+          - {label: add, value: 0.03811}
+        value: 0.3044
+      - errors:
+          - {label: unc, value: 0.00833}
+          - {label: add, value: 0.03779}
+        value: 0.235
+      - errors:
+          - {label: unc, value: 0.00676}
+          - {label: add, value: 0.03805}
+        value: 0.1829
+      - errors:
+          - {label: unc, value: 0.00573}
+          - {label: add, value: 0.0383}
+        value: 0.1462
+      - errors:
+          - {label: unc, value: 0.00447}
+          - {label: add, value: 0.03939}
+        value: 0.1056
+      - errors:
+          - {label: unc, value: 0.00331}
+          - {label: add, value: 0.04461}
+        value: 0.0789
+      - errors:
+          - {label: unc, value: 0.03195}
+          - {label: add, value: 0.03917}
+        value: 0.9823
+      - errors:
+          - {label: unc, value: 0.02199}
+          - {label: add, value: 0.03887}
+        value: 0.6998
+      - errors:
+          - {label: unc, value: 0.01627}
+          - {label: add, value: 0.03863}
+        value: 0.5177
+      - errors:
+          - {label: unc, value: 0.01239}
+          - {label: add, value: 0.03828}
+        value: 0.3866
+      - errors:
+          - {label: unc, value: 0.00942}
+          - {label: add, value: 0.03815}
+        value: 0.2852
+      - errors:
+          - {label: unc, value: 0.00747}
+          - {label: add, value: 0.03811}
+        value: 0.2183
+      - errors:
+          - {label: unc, value: 0.0059}
+          - {label: add, value: 0.0377}
+        value: 0.1655
+      - errors:
+          - {label: unc, value: 0.00495}
+          - {label: add, value: 0.03824}
+        value: 0.1318
+      - errors:
+          - {label: unc, value: 0.00402}
+          - {label: add, value: 0.03863}
+        value: 0.0994
+      - errors:
+          - {label: unc, value: 0.00269}
+          - {label: add, value: 0.04444}
+        value: 0.0648
+      - errors:
+          - {label: unc, value: 0.06438}
+          - {label: add, value: 0.0392}
+        value: 2.0492
+      - errors:
+          - {label: unc, value: 0.04273}
+          - {label: add, value: 0.03904}
+        value: 1.3955
+      - errors:
+          - {label: unc, value: 0.03073}
+          - {label: add, value: 0.03887}
+        value: 0.992
+      - errors:
+          - {label: unc, value: 0.02216}
+          - {label: add, value: 0.03857}
+        value: 0.7031
+      - errors:
+          - {label: unc, value: 0.01577}
+          - {label: add, value: 0.03852}
+        value: 0.4839
+      - errors:
+          - {label: unc, value: 0.01255}
+          - {label: add, value: 0.03844}
+        value: 0.3704
+      - errors:
+          - {label: unc, value: 0.01019}
+          - {label: add, value: 0.03873}
+        value: 0.2809
+      - errors:
+          - {label: unc, value: 0.00816}
+          - {label: add, value: 0.03892}
+        value: 0.2035
+      - errors:
+          - {label: unc, value: 0.00741}
+          - {label: add, value: 0.04}
+        value: 0.158
+      - errors:
+          - {label: unc, value: 0.00706}
+          - {label: add, value: 0.04003}
+        value: 0.1239
+      - errors:
+          - {label: unc, value: 0.00711}
+          - {label: add, value: 0.04211}
+        value: 0.0912
+      - errors:
+          - {label: unc, value: 0.06782}
+          - {label: add, value: 0.03873}
+        value: 1.9829
+      - errors:
+          - {label: unc, value: 0.05088}
+          - {label: add, value: 0.03851}
+        value: 1.4021
+      - errors:
+          - {label: unc, value: 0.0399}
+          - {label: add, value: 0.03838}
+        value: 1.0109
+      - errors:
+          - {label: unc, value: 0.03285}
+          - {label: add, value: 0.03939}
+        value: 0.6966
+      - errors:
+          - {label: unc, value: 0.03502}
+          - {label: add, value: 0.03966}
+        value: 0.5346
+      - errors:
+          - {label: unc, value: 0.01367}
+          - {label: add, value: 0.0386}
+        value: 0.2197
+      - errors:
+          - {label: unc, value: 0.00937}
+          - {label: add, value: 0.03836}
+        value: 0.1752
+      - errors:
+          - {label: unc, value: 0.00724}
+          - {label: add, value: 0.03838}
+        value: 0.1459
+      - errors:
+          - {label: unc, value: 0.00551}
+          - {label: add, value: 0.03926}
+        value: 0.108
+      - errors:
+          - {label: unc, value: 0.00375}
+          - {label: add, value: 0.04337}
+        value: 0.083
+      - errors:
+          - {label: unc, value: 0.02762}
+          - {label: add, value: 0.03922}
+        value: 0.5201
+      - errors:
+          - {label: unc, value: 0.01543}
+          - {label: add, value: 0.03897}
+        value: 0.3736
+      - errors:
+          - {label: unc, value: 0.01166}
+          - {label: add, value: 0.03861}
+        value: 0.2963
+      - errors:
+          - {label: unc, value: 0.00925}
+          - {label: add, value: 0.03864}
+        value: 0.2236
+      - errors:
+          - {label: unc, value: 0.0073}
+          - {label: add, value: 0.03816}
+        value: 0.1677
+      - errors:
+          - {label: unc, value: 0.00596}
+          - {label: add, value: 0.03836}
+        value: 0.1272
+      - errors:
+          - {label: unc, value: 0.00528}
+          - {label: add, value: 0.03901}
+        value: 0.1046
+      - errors:
+          - {label: unc, value: 0.00311}
+          - {label: add, value: 0.04192}
+        value: 0.0668
+      - errors:
+          - {label: unc, value: 0.03691}
+          - {label: add, value: 0.03968}
+        value: 1.0081
+      - errors:
+          - {label: unc, value: 0.0249}
+          - {label: add, value: 0.03926}
+        value: 0.7274
+      - errors:
+          - {label: unc, value: 0.01816}
+          - {label: add, value: 0.03892}
+        value: 0.5283
+      - errors:
+          - {label: unc, value: 0.01349}
+          - {label: add, value: 0.0387}
+        value: 0.3742
+      - errors:
+          - {label: unc, value: 0.01062}
+          - {label: add, value: 0.03858}
+        value: 0.282
+      - errors:
+          - {label: unc, value: 0.00857}
+          - {label: add, value: 0.03836}
+        value: 0.2127
+      - errors:
+          - {label: unc, value: 0.00669}
+          - {label: add, value: 0.03812}
+        value: 0.1553
+      - errors:
+          - {label: unc, value: 0.00573}
+          - {label: add, value: 0.038}
+        value: 0.1242
+      - errors:
+          - {label: unc, value: 0.00524}
+          - {label: add, value: 0.03861}
+        value: 0.1036
+      - errors:
+          - {label: unc, value: 0.00292}
+          - {label: add, value: 0.04054}
+        value: 0.0592
+      - errors:
+          - {label: unc, value: 0.07525}
+          - {label: add, value: 0.03911}
+        value: 2.0887
+      - errors:
+          - {label: unc, value: 0.04706}
+          - {label: add, value: 0.0393}
+        value: 1.3985
+      - errors:
+          - {label: unc, value: 0.03587}
+          - {label: add, value: 0.03913}
+        value: 1.0344
+      - errors:
+          - {label: unc, value: 0.0261}
+          - {label: add, value: 0.03882}
+        value: 0.7109
+      - errors:
+          - {label: unc, value: 0.02014}
+          - {label: add, value: 0.03879}
+        value: 0.5136
+      - errors:
+          - {label: unc, value: 0.01631}
+          - {label: add, value: 0.03928}
+        value: 0.3788
+      - errors:
+          - {label: unc, value: 0.01388}
+          - {label: add, value: 0.03928}
+        value: 0.2872
+      - errors:
+          - {label: unc, value: 0.01231}
+          - {label: add, value: 0.04311}
+        value: 0.2134
+      - errors:
+          - {label: unc, value: 0.01139}
+          - {label: add, value: 0.04399}
+        value: 0.1655
+      - errors:
+          - {label: unc, value: 0.01195}
+          - {label: add, value: 0.0441}
+        value: 0.1415
+      - errors:
+          - {label: unc, value: 0.01286}
+          - {label: add, value: 0.07085}
+        value: 0.1005
+      - errors:
+          - {label: unc, value: 0.09146}
+          - {label: add, value: 0.03928}
+        value: 2.0102
+      - errors:
+          - {label: unc, value: 0.07268}
+          - {label: add, value: 0.03913}
+        value: 1.4024
+      - errors:
+          - {label: unc, value: 0.06}
+          - {label: add, value: 0.03928}
+        value: 1.0103
+      - errors:
+          - {label: unc, value: 0.05841}
+          - {label: add, value: 0.03979}
+        value: 0.7781
+      - errors:
+          - {label: unc, value: 0.05719}
+          - {label: add, value: 0.04664}
+        value: 0.5129
+      - errors:
+          - {label: unc, value: 0.01881}
+          - {label: add, value: 0.03846}
+        value: 0.2205
+      - errors:
+          - {label: unc, value: 0.01175}
+          - {label: add, value: 0.03846}
+        value: 0.1685
+      - errors:
+          - {label: unc, value: 0.0085}
+          - {label: add, value: 0.03877}
+        value: 0.1238
+      - errors:
+          - {label: unc, value: 0.00738}
+          - {label: add, value: 0.0385}
+        value: 0.1143
+      - errors:
+          - {label: unc, value: 0.00436}
+          - {label: add, value: 0.04115}
+        value: 0.0797
+      - errors:
+          - {label: unc, value: 0.03599}
+          - {label: add, value: 0.03962}
+        value: 0.4988
+      - errors:
+          - {label: unc, value: 0.01919}
+          - {label: add, value: 0.0395}
+        value: 0.3727
+      - errors:
+          - {label: unc, value: 0.0132}
+          - {label: add, value: 0.03906}
+        value: 0.2683
+      - errors:
+          - {label: unc, value: 0.0116}
+          - {label: add, value: 0.03874}
+        value: 0.2292
+      - errors:
+          - {label: unc, value: 0.00863}
+          - {label: add, value: 0.03852}
+        value: 0.1537
+      - errors:
+          - {label: unc, value: 0.00784}
+          - {label: add, value: 0.03833}
+        value: 0.1294
+      - errors:
+          - {label: unc, value: 0.00605}
+          - {label: add, value: 0.03867}
+        value: 0.0869
+      - errors:
+          - {label: unc, value: 0.00385}
+          - {label: add, value: 0.04099}
+        value: 0.0644
+      - errors:
+          - {label: unc, value: 0.0444}
+          - {label: add, value: 0.04018}
+        value: 0.9855
+      - errors:
+          - {label: unc, value: 0.02805}
+          - {label: add, value: 0.03971}
+        value: 0.6991
+      - errors:
+          - {label: unc, value: 0.02009}
+          - {label: add, value: 0.0394}
+        value: 0.4974
+      - errors:
+          - {label: unc, value: 0.01604}
+          - {label: add, value: 0.03914}
+        value: 0.37
+      - errors:
+          - {label: unc, value: 0.01314}
+          - {label: add, value: 0.03897}
+        value: 0.2833
+      - errors:
+          - {label: unc, value: 0.01079}
+          - {label: add, value: 0.03866}
+        value: 0.2152
+      - errors:
+          - {label: unc, value: 0.00907}
+          - {label: add, value: 0.03837}
+        value: 0.1668
+      - errors:
+          - {label: unc, value: 0.00726}
+          - {label: add, value: 0.03871}
+        value: 0.1178
+      - errors:
+          - {label: unc, value: 0.00677}
+          - {label: add, value: 0.0392}
+        value: 0.1
+      - errors:
+          - {label: unc, value: 0.00379}
+          - {label: add, value: 0.04203}
+        value: 0.059
+      - errors:
+          - {label: unc, value: 0.09307}
+          - {label: add, value: 0.03963}
+        value: 2.1016
+      - errors:
+          - {label: unc, value: 0.05732}
+          - {label: add, value: 0.03973}
+        value: 1.4578
+      - errors:
+          - {label: unc, value: 0.04118}
+          - {label: add, value: 0.03958}
+        value: 0.9783
+      - errors:
+          - {label: unc, value: 0.03342}
+          - {label: add, value: 0.0393}
+        value: 0.7287
+      - errors:
+          - {label: unc, value: 0.02678}
+          - {label: add, value: 0.03919}
+        value: 0.5246
+      - errors:
+          - {label: unc, value: 0.02371}
+          - {label: add, value: 0.03983}
+        value: 0.4158
+      - errors:
+          - {label: unc, value: 0.02041}
+          - {label: add, value: 0.04116}
+        value: 0.2993
+      - errors:
+          - {label: unc, value: 0.01835}
+          - {label: add, value: 0.04261}
+        value: 0.2234
+      - errors:
+          - {label: unc, value: 0.01911}
+          - {label: add, value: 0.04831}
+        value: 0.1987
+      - errors:
+          - {label: unc, value: 0.01416}
+          - {label: add, value: 0.06017}
+        value: 0.0944
+      - errors:
+          - {label: unc, value: 0.0216}
+          - {label: add, value: 0.06213}
+        value: 0.1249
+      - errors:
+          - {label: unc, value: 0.036}
+          - {label: add, value: 0.04}
+        value: 0.472
+      - errors:
+          - {label: unc, value: 0.02004}
+          - {label: add, value: 0.03977}
+        value: 0.3762
+      - errors:
+          - {label: unc, value: 0.01516}
+          - {label: add, value: 0.03953}
+        value: 0.3036
+      - errors:
+          - {label: unc, value: 0.01218}
+          - {label: add, value: 0.03898}
+        value: 0.2278
+      - errors:
+          - {label: unc, value: 0.0104}
+          - {label: add, value: 0.03871}
+        value: 0.1798
+      - errors:
+          - {label: unc, value: 0.00823}
+          - {label: add, value: 0.03855}
+        value: 0.1245
+      - errors:
+          - {label: unc, value: 0.00672}
+          - {label: add, value: 0.03852}
+        value: 0.0893
+      - errors:
+          - {label: unc, value: 0.00379}
+          - {label: add, value: 0.03965}
+        value: 0.0565
+      - errors:
+          - {label: unc, value: 0.04529}
+          - {label: add, value: 0.04083}
+        value: 0.9582
+      - errors:
+          - {label: unc, value: 0.02711}
+          - {label: add, value: 0.04041}
+        value: 0.6414
+      - errors:
+          - {label: unc, value: 0.0208}
+          - {label: add, value: 0.04008}
+        value: 0.493
+      - errors:
+          - {label: unc, value: 0.01617}
+          - {label: add, value: 0.03981}
+        value: 0.3517
+      - errors:
+          - {label: unc, value: 0.01418}
+          - {label: add, value: 0.03973}
+        value: 0.292
+      - errors:
+          - {label: unc, value: 0.01097}
+          - {label: add, value: 0.03942}
+        value: 0.207
+      - errors:
+          - {label: unc, value: 0.00889}
+          - {label: add, value: 0.03952}
+        value: 0.1498
+      - errors:
+          - {label: unc, value: 0.00854}
+          - {label: add, value: 0.03928}
+        value: 0.1385
+      - errors:
+          - {label: unc, value: 0.00644}
+          - {label: add, value: 0.03927}
+        value: 0.0876
+      - errors:
+          - {label: unc, value: 0.00411}
+          - {label: add, value: 0.04279}
+        value: 0.0617
+      - errors:
+          - {label: unc, value: 0.09818}
+          - {label: add, value: 0.04001}
+        value: 2.1194
+      - errors:
+          - {label: unc, value: 0.05553}
+          - {label: add, value: 0.04008}
+        value: 1.3834
+      - errors:
+          - {label: unc, value: 0.04352}
+          - {label: add, value: 0.03986}
+        value: 1.0216
+      - errors:
+          - {label: unc, value: 0.03465}
+          - {label: add, value: 0.03967}
+        value: 0.7543
+      - errors:
+          - {label: unc, value: 0.02693}
+          - {label: add, value: 0.03953}
+        value: 0.5242
+      - errors:
+          - {label: unc, value: 0.02157}
+          - {label: add, value: 0.04017}
+        value: 0.3684
+      - errors:
+          - {label: unc, value: 0.01889}
+          - {label: add, value: 0.04163}
+        value: 0.2767
+      - errors:
+          - {label: unc, value: 0.01798}
+          - {label: add, value: 0.0431}
+        value: 0.2283
+      - errors:
+          - {label: unc, value: 0.01897}
+          - {label: add, value: 0.04873}
+        value: 0.2003
+      - errors:
+          - {label: unc, value: 0.01788}
+          - {label: add, value: 0.05974}
+        value: 0.1366
+independent_variables:
+  - header: {name: z}
+    values:
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+      - {high: 0.75, low: 0.7, value: 0.725}
+      - {high: 0.85, low: 0.75, value: 0.8}
+      - {high: 0.25, low: 0.2, value: 0.225}
+      - {high: 0.3, low: 0.25, value: 0.275}
+      - {high: 0.35, low: 0.3, value: 0.325}
+      - {high: 0.4, low: 0.35, value: 0.375}
+      - {high: 0.45, low: 0.4, value: 0.425}
+      - {high: 0.5, low: 0.45, value: 0.475}
+      - {high: 0.55, low: 0.5, value: 0.525}
+      - {high: 0.6, low: 0.55, value: 0.575}
+      - {high: 0.65, low: 0.6, value: 0.625}
+      - {high: 0.7, low: 0.65, value: 0.675}
+  - header: {name: x}
+    values:
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.01, low: 0.004, value: 0.007}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.02, low: 0.01, value: 0.015}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.03, low: 0.02, value: 0.025}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.04, low: 0.03, value: 0.035}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.06, low: 0.04, value: 0.05}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.1, low: 0.06, value: 0.08}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.14, low: 0.1, value: 0.12}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.18, low: 0.14, value: 0.16}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+      - {high: 0.4, low: 0.18, value: 0.29}
+  - header: {name: y}
+    values:
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.7, low: 0.5, value: 0.6}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.15, low: 0.1, value: 0.125}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.2, low: 0.15, value: 0.175}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.3, low: 0.2, value: 0.25}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+      - {high: 0.5, low: 0.3, value: 0.4}
+  - header: {name: Q2}
+    values:
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 0.842863}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 1.264295}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 0.790184}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.128834}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 1.806135}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 2.709202}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 0.940695}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.316973}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 1.843763}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 1.881391}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 2.633947}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 3.762781}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 3.010225}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 4.214315}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 9.63272}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 4.515338}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 6.321473}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 9.030675}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 14.44908}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 21.67362}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 6.02045}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 8.42863}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 12.0409}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 19.26544}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 15.276892}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 21.824131}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}
+      - {value: 34.91861}


### PR DESCRIPTION
This pull request adds the MontBlanc input cards and COMPASS data files used in the unidentified hadron, Pion and Kaon FFs study associated with arXiv: 2605.31325 and arXiv: 2606.16754.

The purpose of this pull request is documentation and provenance. It is intended to make the configuration files and COMPASS data used in the analysis publicly inspectable within the MontBlanc repository structure. 